### PR TITLE
feat: custom primary color and fix tooltip bug

### DIFF
--- a/.dumi/app.tsx
+++ b/.dumi/app.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ConfigProvider } from 'antd';
+
+export function rootContainer(container: React.ReactNode) {
+  return (
+    <ConfigProvider
+      theme={{
+        token: {
+          colorPrimary: '#000',
+        },
+      }}
+    >
+      {container}
+    </ConfigProvider>
+  );
+}

--- a/.dumi/tsconfig.json
+++ b/.dumi/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*"]
+}

--- a/packages/web3/src/address/index.tsx
+++ b/packages/web3/src/address/index.tsx
@@ -4,7 +4,7 @@ import { Space, Tooltip, message, ConfigProvider } from 'antd';
 import React, { useContext } from 'react';
 import { useStyle } from './style';
 import classNames from 'classnames';
-import { writeCopyText } from '../utils';
+import { writeCopyText, fillWith0x } from '../utils';
 
 export interface AddressProps {
   ellipsis?:
@@ -37,7 +37,7 @@ export const Address: React.FC<AddressProps> = (props) => {
     return null;
   }
 
-  const filledAddress = address.startsWith('0x') ? address : `0x${address}`;
+  const filledAddress = fillWith0x(address);
   const displayTooltip = tooltip === undefined || tooltip === true ? filledAddress : tooltip;
 
   return wrapSSR(

--- a/packages/web3/src/connect-button/__tests__/index.test.tsx
+++ b/packages/web3/src/connect-button/__tests__/index.test.tsx
@@ -1,18 +1,8 @@
 import { ConnectButton } from '..';
-import { fireEvent, render } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mockClipboard } from '../../utils/test-utils';
-import { readCopyText } from '../../utils';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
 
 describe('ConnectButton', () => {
-  let resetMockClipboard: () => void;
-  beforeEach(() => {
-    resetMockClipboard = mockClipboard();
-  });
-  afterEach(() => {
-    resetMockClipboard();
-  });
-
   it('mount correctly', () => {
     expect(() => render(<ConnectButton />)).not.toThrow();
   });
@@ -38,97 +28,5 @@ describe('ConnectButton', () => {
   it('display name when not has address', () => {
     const { baseElement } = render(<ConnectButton name="wanderingearth.eth" connected />);
     expect(baseElement.querySelector('.ant-btn')?.textContent).toBe('wanderingearth.eth');
-  });
-
-  it('tooltip show address when has name', () => {
-    const { baseElement } = render(
-      <ConnectButton
-        name="wanderingearth.eth"
-        address="3ea2cfd153b8d8505097b81c87c11f5d05097c18"
-        connected
-        tooltip={{ open: true }}
-      />,
-    );
-    expect(baseElement.querySelector('.ant-btn')?.textContent).toBe('wanderingearth.eth');
-    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
-    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent).toBe('0x3ea2cf...097c18');
-    expect(baseElement.querySelector('.anticon-copy')).not.toBeNull();
-  });
-
-  it('display tooltip', () => {
-    const { baseElement } = render(
-      <ConnectButton address="3ea2cfd153b8d8505097b81c87c11f5d05097c18" tooltip={{ open: true }} />,
-    );
-    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
-    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent).toBe('0x3ea2cf...097c18');
-    expect(baseElement.querySelector('.anticon-copy')).not.toBeNull();
-  });
-
-  it('disabled copyable in tooltip', () => {
-    const { baseElement } = render(
-      <ConnectButton
-        address="3ea2cfd153b8d8505097b81c87c11f5d05097c18"
-        tooltip={{ open: true, copyable: false }}
-      />,
-    );
-    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
-    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent?.trim()).toBe(
-      '0x3ea2cf...097c18',
-    );
-    expect(baseElement.querySelector('.anticon-copy')).toBeNull();
-  });
-
-  it('custom title in tooltip', () => {
-    const { baseElement } = render(
-      <ConnectButton
-        address="3ea2cfd153b8d8505097b81c87c11f5d05097c18"
-        tooltip={{ open: true, title: 'aaaaaabbbbbbcccccc' }}
-      />,
-    );
-    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
-    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent?.trim()).toBe(
-      'aaaaaabbbbbbcccccc',
-    );
-  });
-
-  it('should not display tooltip when not custom title and without address in tooltip', () => {
-    const { baseElement } = render(<ConnectButton tooltip />);
-    expect(baseElement.querySelector('.ant-tooltip')).toBeNull();
-  });
-
-  it('should copy text after click copy icon', async () => {
-    const { baseElement } = render(
-      <ConnectButton address="3ea2cfd153b8d8505097b81c87c11f5d05097c18" tooltip={{ open: true }} />,
-    );
-    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
-    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent).toBe('0x3ea2cf...097c18');
-    expect(baseElement.querySelector('.anticon-copy')).not.toBeNull();
-    fireEvent.click(baseElement.querySelector('.anticon-copy')!);
-    await vi.waitFor(() => {
-      expect(baseElement.querySelector('.ant-message')).not.toBeNull();
-      expect(baseElement.querySelector('.ant-message-notice-content')?.textContent).toBe(
-        'Address Copied!',
-      );
-      expect(readCopyText()).resolves.toBe('0x3ea2cfd153b8d8505097b81c87c11f5d05097c18');
-    });
-  });
-
-  it('should copy text after click copy icon in custom title mode', async () => {
-    const { baseElement } = render(
-      <ConnectButton tooltip={{ open: true, title: 'aaaaaabbbbbbcccccc' }} />,
-    );
-    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
-    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent?.trim()).toBe(
-      'aaaaaabbbbbbcccccc',
-    );
-    expect(baseElement.querySelector('.anticon-copy')).not.toBeNull();
-    fireEvent.click(baseElement.querySelector('.anticon-copy')!);
-    await vi.waitFor(() => {
-      expect(baseElement.querySelector('.ant-message')).not.toBeNull();
-      expect(baseElement.querySelector('.ant-message-notice-content')?.textContent).toBe(
-        'Address Copied!',
-      );
-      expect(readCopyText()).resolves.toBe('aaaaaabbbbbbcccccc');
-    });
   });
 });

--- a/packages/web3/src/connect-button/__tests__/tooltip.test.tsx
+++ b/packages/web3/src/connect-button/__tests__/tooltip.test.tsx
@@ -1,0 +1,96 @@
+import { ConnectButton } from '..';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClipboard } from '../../utils/test-utils';
+import { readCopyText } from '../../utils';
+
+describe('ConnectButton', () => {
+  let resetMockClipboard: () => void;
+  beforeEach(() => {
+    resetMockClipboard = mockClipboard();
+  });
+  afterEach(() => {
+    resetMockClipboard();
+  });
+
+  it('display tooltip', () => {
+    const { baseElement } = render(
+      <ConnectButton address="3ea2cfd153b8d8505097b81c87c11f5d05097c18" tooltip={{ open: true }} />,
+    );
+    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
+    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent?.trim()).toBe(
+      '0x3ea2cfd153b8d8505097b81c87c11f5d05097c18',
+    );
+    expect(baseElement.querySelector('.anticon-copy')).not.toBeNull();
+  });
+
+  it('disabled copyable in tooltip', () => {
+    const { baseElement } = render(
+      <ConnectButton
+        address="3ea2cfd153b8d8505097b81c87c11f5d05097c18"
+        tooltip={{ open: true, copyable: false }}
+      />,
+    );
+    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
+    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent?.trim()).toBe(
+      '0x3ea2cfd153b8d8505097b81c87c11f5d05097c18',
+    );
+    expect(baseElement.querySelector('.anticon-copy')).toBeNull();
+  });
+
+  it('custom title in tooltip', () => {
+    const { baseElement } = render(
+      <ConnectButton
+        address="3ea2cfd153b8d8505097b81c87c11f5d05097c18"
+        tooltip={{ open: true, title: 'aaaaaabbbbbbcccccc' }}
+      />,
+    );
+    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
+    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent?.trim()).toBe(
+      'aaaaaabbbbbbcccccc',
+    );
+  });
+
+  it('should not display tooltip when not custom title and without address in tooltip', () => {
+    const { baseElement } = render(<ConnectButton tooltip />);
+    expect(baseElement.querySelector('.ant-tooltip')).toBeNull();
+  });
+
+  it('should copy text after click copy icon', async () => {
+    const { baseElement } = render(
+      <ConnectButton address="3ea2cfd153b8d8505097b81c87c11f5d05097c18" tooltip={{ open: true }} />,
+    );
+    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
+    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent?.trim()).toBe(
+      '0x3ea2cfd153b8d8505097b81c87c11f5d05097c18',
+    );
+    expect(baseElement.querySelector('.anticon-copy')).not.toBeNull();
+    fireEvent.click(baseElement.querySelector('.anticon-copy')!);
+    await vi.waitFor(() => {
+      expect(baseElement.querySelector('.ant-message')).not.toBeNull();
+      expect(baseElement.querySelector('.ant-message-notice-content')?.textContent).toBe(
+        'Address Copied!',
+      );
+      expect(readCopyText()).resolves.toBe('0x3ea2cfd153b8d8505097b81c87c11f5d05097c18');
+    });
+  });
+
+  it('should copy text after click copy icon in custom title mode', async () => {
+    const { baseElement } = render(
+      <ConnectButton tooltip={{ open: true, title: 'aaaaaabbbbbbcccccc' }} />,
+    );
+    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
+    expect(baseElement.querySelector('.ant-tooltip-inner')?.textContent?.trim()).toBe(
+      'aaaaaabbbbbbcccccc',
+    );
+    expect(baseElement.querySelector('.anticon-copy')).not.toBeNull();
+    fireEvent.click(baseElement.querySelector('.anticon-copy')!);
+    await vi.waitFor(() => {
+      expect(baseElement.querySelector('.ant-message')).not.toBeNull();
+      expect(baseElement.querySelector('.ant-message-notice-content')?.textContent?.trim()).toBe(
+        'Address Copied!',
+      );
+      expect(readCopyText()).resolves.toBe('aaaaaabbbbbbcccccc');
+    });
+  });
+});

--- a/packages/web3/src/connect-button/connect-button.tsx
+++ b/packages/web3/src/connect-button/connect-button.tsx
@@ -7,6 +7,7 @@ import { ConnectButtonTooltip } from './tooltip';
 import { ChainSelect } from './chain-select';
 import { ProfileModal } from './profile-modal';
 import { useStyle } from './style';
+import { fillWith0x } from '../utils';
 
 export const ConnectButton: React.FC<ConnectButtonProps> = (props) => {
   const {
@@ -92,26 +93,14 @@ export const ConnectButton: React.FC<ConnectButtonProps> = (props) => {
   const mergedTooltipCopyable: ConnectButtonTooltipProps['copyable'] =
     typeof tooltip === 'object' ? tooltip.copyable !== false : !!tooltip;
 
-  const customTooltipTitle = typeof tooltip === 'object' && tooltip.title !== undefined;
-
-  const tooltipTitle = customTooltipTitle ? (
-    tooltip.title
-  ) : (
-    <Address
-      ellipsis={{
-        headClip: 8,
-        tailClip: 6,
-      }}
-      copyable={mergedTooltipCopyable}
-      tooltip={false}
-      address={address}
-    />
-  );
-
+  let tooltipTitle: string = tooltip && address ? fillWith0x(address) : '';
+  if (typeof tooltip === 'object' && typeof tooltip.title === 'string') {
+    tooltipTitle = tooltip.title;
+  }
   return wrapSSR(
-    tooltip || (!customTooltipTitle && !!address) ? (
+    tooltipTitle ? (
       <ConnectButtonTooltip
-        copyable={customTooltipTitle && mergedTooltipCopyable}
+        copyable={mergedTooltipCopyable}
         title={tooltipTitle}
         {...(typeof tooltip === 'object' ? tooltip : {})}
       >

--- a/packages/web3/src/connect-button/demos/simple.tsx
+++ b/packages/web3/src/connect-button/demos/simple.tsx
@@ -1,7 +1,7 @@
 import { ConnectButton } from '@ant-design/web3';
 
 const App: React.FC = () => {
-  return <ConnectButton />;
+  return <ConnectButton address="3ea2cfd153b8d8505097b81c87c11f5d05097c18" connected />;
 };
 
 export default App;

--- a/packages/web3/src/connect-button/demos/type.tsx
+++ b/packages/web3/src/connect-button/demos/type.tsx
@@ -1,0 +1,19 @@
+import { ConnectButton } from '@ant-design/web3';
+import { Space } from 'antd';
+
+const App: React.FC = () => {
+  return (
+    <Space>
+      <ConnectButton
+        type="primary"
+        address="3ea2cfd153b8d8505097b81c87c11f5d05097c18"
+        tooltip
+        connected
+      />
+      <ConnectButton type="dashed" address="3ea2cfd153b8d8505097b81c87c11f5d05097c18" connected />
+      <ConnectButton type="link" address="3ea2cfd153b8d8505097b81c87c11f5d05097c18" connected />
+    </Space>
+  );
+};
+
+export default App;

--- a/packages/web3/src/connect-button/index.md
+++ b/packages/web3/src/connect-button/index.md
@@ -21,6 +21,10 @@ A Button for connect chain quickly.
 
 <code src="./demos/name.tsx"></code>
 
+## Different Types
+
+<code src="./demos/type.tsx"></code>
+
 ## API
 
 | Property | Description | Type | Default | Version |

--- a/packages/web3/src/connect-button/index.zh-CN.md
+++ b/packages/web3/src/connect-button/index.zh-CN.md
@@ -19,6 +19,10 @@ group: 组件
 
 <code src="./demos/name.tsx"></code>
 
+## 不同类型的按钮
+
+<code src="./demos/type.tsx"></code>
+
 ## API
 
 | 属性 | 描述 | 类型 | 默认值 | 版本 |

--- a/packages/web3/src/utils/format.ts
+++ b/packages/web3/src/utils/format.ts
@@ -1,0 +1,4 @@
+export const fillWith0x = (address: string = ''): string => {
+  const filledAddress = address.startsWith('0x') ? address : `0x${address}`;
+  return filledAddress;
+};

--- a/packages/web3/src/utils/index.ts
+++ b/packages/web3/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './browser';
+export * from './format';


### PR DESCRIPTION
- 修改文档的 primaryColor，设计稿中的主色调的修改应该是通过 antd Design token  实现的，不应该在组件中写死，如果用户没有配置的话就应该用 antd 默认的主题色， @kiner-tang ConnectModal 里面的逻辑应该也要修改。
- 修改了 tooltip 的显示逻辑：默认补全地址的 0x 前缀以及不缩略显示地址