### PR TITLE
feat: 增加browser-link组件的单元测试

### DIFF
--- a/packages/web3/src/browser-link/__tests__/index.test.tsx
+++ b/packages/web3/src/browser-link/__tests__/index.test.tsx
@@ -8,4 +8,33 @@ describe('BrowserLink', () => {
       render(<BrowserLink address="0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B" />),
     ).not.toThrow();
   });
+
+  it('renders address link correctly', () => {
+    const address = '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B';
+    const { baseElement } = render(<BrowserLink address={address} type="address" />);
+
+    const link = baseElement.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('href')).toBe(`https://etherscan.io/address/${address}`);
+  });
+
+  it('renders transaction link correctly', () => {
+    const transactionHash = '0xabc123def456';
+    const { baseElement } = render(<BrowserLink address={transactionHash} type="transaction" />);
+
+    const link = baseElement.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('href')).toBe(`https://etherscan.io/tx/${transactionHash}`);
+  });
+
+  it('renders custom href correctly', () => {
+    const customHref = 'https://custom-link.com';
+    const { baseElement } = render(
+      <BrowserLink address="0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B" href={customHref} />,
+    );
+
+    const link = baseElement.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('href')).toBe(customHref);
+  });
 });


### PR DESCRIPTION
增加3个单测：
1. 渲染地址链接的测试用例。
2. 渲染交易链接的测试用例。
3. 渲染自定义 href 的测试用例。