### PR TITLE
feat: 增加nft image test

### DIFF
--- a/packages/web3/src/nft-image/__tests__/index.test.tsx
+++ b/packages/web3/src/nft-image/__tests__/index.test.tsx
@@ -1,0 +1,23 @@
+import { NFTImage } from '..';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+describe('NFTImage', () => {
+  it('renders correctly with valid address and tokenId', () => {
+    const address = '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B';
+    const tokenId = 123;
+
+    expect(() =>
+      render(<NFTImage address={address} tokenId={tokenId} alt="NFT Image" />),
+    ).not.toThrow();
+  });
+
+  it('renders correctly with valid address and bigint tokenId', () => {
+    const address = '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B';
+    const tokenId = BigInt(123);
+
+    expect(() =>
+      render(<NFTImage address={address} tokenId={tokenId} alt="NFT Image" />),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
增加nft image单测：
1. 使用有效的地址和 tokenId 进行正常渲染的测试用例。
2. 使用有效的地址和 bigint 类型的 tokenId 进行正常渲染的测试用例。