### PR TITLE
Update ethereum-circle-filled.svg

### DIFF
--- a/packages/icons/src/svgs/ethereum-circle-filled.svg
+++ b/packages/icons/src/svgs/ethereum-circle-filled.svg
@@ -2,7 +2,7 @@
 <svg viewBox="0 0 1024 1024"
   xmlns="http://www.w3.org/2000/svg">
   <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-    <circle fill="#000000" cx="513" cy="512" r="512"></circle>
+    <circle fill="currentColor" cx="513" cy="512" r="512"></circle>
     <g fill="#FFFFFF">
         <rect fill-opacity="0" x="0" y="0" width="1024" height="1024"></rect>
         <g transform="translate(286, 152)">


### PR DESCRIPTION
修复图标无法通过`style:{ color: 'red'}` 的方式来修改颜色