### PR TITLE
feat: add link for wallet qrcode for support connect in mobile

### DIFF
--- a/.changeset/fuzzy-balloons-check.md
+++ b/.changeset/fuzzy-balloons-check.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+feat: add link for wallet qrcode for support connect in mobile

--- a/packages/web3/src/connect-modal/__tests__/__snapshots__/basic.test.tsx.snap
+++ b/packages/web3/src/connect-modal/__tests__/__snapshots__/basic.test.tsx.snap
@@ -379,6 +379,11 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                           />
                         </svg>
                       </div>
+                      <a
+                        class="ant-web3-connect-modal-qr-code-link ant-web3-connect-modal-qr-code-link-loading"
+                      >
+                        Click to connect directly
+                      </a>
                     </div>
                     <div
                       class="ant-web3-connect-modal-qr-code-tips"
@@ -791,6 +796,11 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                           />
                         </svg>
                       </div>
+                      <a
+                        class="ant-web3-connect-modal-qr-code-link ant-web3-connect-modal-qr-code-link-loading"
+                      >
+                        Click to connect directly
+                      </a>
                     </div>
                     <div
                       class="ant-web3-connect-modal-qr-code-tips"

--- a/packages/web3/src/connect-modal/__tests__/qrcode.test.tsx
+++ b/packages/web3/src/connect-modal/__tests__/qrcode.test.tsx
@@ -1,0 +1,49 @@
+import { ConnectModal } from '@ant-design/web3';
+import { guide } from './mock';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+describe('ConnectModal with qrcode', () => {
+  it('show connect wallect link', async () => {
+    const App = () => (
+      <ConnectModal
+        open
+        title="ConnectModal"
+        footer="Powered by AntChain"
+        walletList={[
+          {
+            icon: 'https://xsgames.co/randomusers/avatar.php?g=pixel&key=0',
+            name: 'Wallect Connect',
+            remark: '备注',
+            app: {
+              link: 'https://test.com/xxx',
+            },
+            group: 'Popular',
+            getQrCode: () =>
+              Promise.resolve({
+                uri: 'wc:f7a2ae968db3720de3efa7f088a3a05a746c011bb972a4dae0a61abe66632e3d@2?relay-protocol=irn&symKey=85bf278d8a4240154c449939eb047863585619c9c7acaa78657606d66c5630b3',
+              }),
+          },
+        ]}
+        guide={guide}
+      />
+    );
+    const { baseElement } = render(<App />);
+
+    fireEvent.click(baseElement.querySelector('.ant-web3-connect-modal-wallet-item')!);
+    waitFor(() => {
+      expect(
+        baseElement.querySelector('.ant-web3-connect-modal-qr-code-link-loading'),
+      ).not.toBeNull();
+      expect(baseElement.querySelector('.ant-web3-connect-modal-qr-code-link')?.textContent).toBe(
+        'Click to connect directly',
+      );
+      expect(
+        baseElement.querySelector('.ant-web3-connect-modal-qr-code-link')?.getAttribute('href'),
+      ).toBe(
+        'wc:f7a2ae968db3720de3efa7f088a3a05a746c011bb972a4dae0a61abe66632e3d@2?relay-protocol=irn&symKey=85bf278d8a4240154c449939eb047863585619c9c7acaa78657606d66c5630b3',
+      );
+    });
+    expect(baseElement.querySelector('.ant-web3-connect-modal-qr-code-link-loading')).toBeNull();
+  });
+});

--- a/packages/web3/src/connect-modal/components/QrCode.tsx
+++ b/packages/web3/src/connect-modal/components/QrCode.tsx
@@ -3,6 +3,7 @@ import type { Wallet } from '../interface';
 import MainPanelHeader from './MainPanelHeader';
 import { connectModalContext } from '../context';
 import { Button, QRCode } from 'antd';
+import classNames from 'classnames';
 
 export type QrCodeProps = {
   wallet: Wallet;
@@ -41,6 +42,14 @@ const QrCode: React.FC<QrCodeProps> = (props) => {
           iconSize={60}
           type="svg"
         />
+        <a
+          className={classNames(`${prefixCls}-qr-code-link`, {
+            [`${prefixCls}-qr-code-link-loading`]: loading,
+          })}
+          href={!loading ? qrCodeValue : undefined}
+        >
+          Click to connect directly
+        </a>
       </div>
       <div className={`${prefixCls}-qr-code-tips`}>
         Don&apos;t have {wallet.name}?

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -380,12 +380,21 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
                 marginInline: 'auto',
               },
             },
+            [`${componentCls}-qr-code-link`]: {
+              marginTop: token.marginSM,
+              textAlign: 'center',
+              display: 'block',
+            },
+            [`${componentCls}-qr-code-link-loading`]: {
+              cursor: 'not-allowed',
+              color: token.colorTextDisabled,
+            },
             [`${componentCls}-qr-code-tips`]: {
               color: token.listItemDescriptionColor,
               fontSize: token.fontSizeLG,
               position: 'relative',
               width: '100%',
-              marginBlockStart: 58,
+              marginBlockStart: token.marginMD,
               [`${componentCls}-get-wallet-btn`]: {
                 position: 'absolute',
                 right: 0,


### PR DESCRIPTION
添加二维码的连接，这样手机访问的时候可以直接点击链接连接，而不需要扫码，因为没办法自己扫自己。

<img width="823" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/1061968/2adfcbec-b243-49fb-bd4e-c23e56ea49d0">
