### PR TITLE
style: fix dumi-default-footer line-height

### DIFF
--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -13,6 +13,10 @@
     font-size: 80px;
   }
 
+  .dumi-default-content-footer {
+    line-height: 1.2;
+  }
+
   .home {
     main {
       max-width: none;


### PR DESCRIPTION
问题描述：官网英文版，footer 中的标题显示不全

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/cbc0cbe0-c9e3-4fba-8af9-831a29e368e8)

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/e8e9d24c-d66a-48fd-9049-dd753188f30c)

我猜想原因可能是
footer的height是14px，但是nav的a标签内部font-size是16px，所以这个lineheight不对，导致显示异常，设置成1.2可以解决这个问题
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/ce6bdbc0-9a72-45a0-9a26-a88ef8310450)
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/dd940f1e-2099-4d2e-9d8b-4d90de19a117)

修复后的效果
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/f244b50f-9bdd-4915-8f55-16bd70d9e41a)

