### PR TITLE
chore: release 1.0.0

### DIFF
--- a/.changeset/calm-planes-provide.md
+++ b/.changeset/calm-planes-provide.md
@@ -1,9 +1,0 @@
----
-'@ant-design/web3-assets': major
-'@ant-design/web3-common': major
-'@ant-design/web3-icons': major
-'@ant-design/web3-wagmi': major
-'@ant-design/web3': major
----
-
-docs: Update new logo and prepare release 1.0.0

--- a/.changeset/fuzzy-jars-breathe.md
+++ b/.changeset/fuzzy-jars-breathe.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix: add @ant-design/web3-assets dep in @ant-design/web3

--- a/.changeset/smart-goats-approve.md
+++ b/.changeset/smart-goats-approve.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-chore: release @ant-design/web3 1.0.1

--- a/.changeset/smart-goats-approve.md
+++ b/.changeset/smart-goats-approve.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+chore: release @ant-design/web3 1.0.1

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ant-design/web3-assets
 
+## 1.0.0
+
+### Major Changes
+
+- f330908: docs: Update new logo and prepare release 1.0.0
+
+### Patch Changes
+
+- Updated dependencies [f330908]
+  - @ant-design/web3-common@1.0.0
+  - @ant-design/web3-icons@1.0.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-assets",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/lib/index.js",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-common
 
+## 1.0.0
+
+### Major Changes
+
+- f330908: docs: Update new logo and prepare release 1.0.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-common",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/lib/index.js",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-icons
 
+## 1.0.0
+
+### Major Changes
+
+- f330908: docs: Update new logo and prepare release 1.0.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-icons",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/lib/index.js",

--- a/packages/wagmi/CHANGELOG.md
+++ b/packages/wagmi/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ant-design/web3-wagmi
 
+## 1.0.0
+
+### Major Changes
+
+- f330908: docs: Update new logo and prepare release 1.0.0
+
+### Patch Changes
+
+- Updated dependencies [f330908]
+  - @ant-design/web3-assets@1.0.0
+  - @ant-design/web3-common@1.0.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-wagmi",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/lib/index.js",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3
 
+## 1.0.1
+
+### Patch Changes
+
+- fd51e5d: chore: release @ant-design/web3 1.0.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ant-design/web3
 
+## 1.0.0
+
+### Major Changes
+
+- f330908: docs: Update new logo and prepare release 1.0.0
+
+### Patch Changes
+
+- 5a86696: fix: add @ant-design/web3-assets dep in @ant-design/web3
+- Updated dependencies [f330908]
+  - @ant-design/web3-assets@1.0.0
+  - @ant-design/web3-common@1.0.0
+  - @ant-design/web3-icons@1.0.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/lib/index.js",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/lib/index.js",


### PR DESCRIPTION
@ant-design/web3 这个包之前误发过 1.0.0，unpublished 了也不能重发。所以发的是 1.0.1