### PR TITLE
docs: optimize document

### DIFF
--- a/docs/course/dev-connect.zh-CN.md
+++ b/docs/course/dev-connect.zh-CN.md
@@ -15,9 +15,11 @@ order: 2
 
 首先，同[快速开始](../guide/quick-start.zh-CN.md)中文档指引的类似，我们需要安装一些依赖。在上一篇课程中，我们已经安装了 `antd` 和 `@ant-design/web3`，所以我们接下来只需要安装 `@ant-design/web3-wagmi` 和 `wagmi`。
 
-```bash
-npm install @ant-design/web3-wagmi wagmi --save
-```
+<br />
+
+<NormalInstallDependencies packageNames="@ant-design/web3-wagmi wagmi" save="true"></NormalInstallDependencies>
+
+<br />
 
 `@ant-design/web3` 是一个 UI 组件库，它通过不同的[适配器](../guide/adapter.zh-CN.md)和不同的区块链连接。本课程中，我们主要基于的是[以太坊](https://ethereum.org/zh/)。对应的，我们也将使用[以太坊的适配器](../../packages/web3/src/wagmi/index.zh-CN.md)来实现课程的需求。
 


### PR DESCRIPTION
感觉这一块的安装命令可以参考 `快速开始`中的
<img width="1137" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/d45491cd-3b38-45e8-86dd-33cb9fd42522">

<img width="982" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/4a1074f1-2b2b-437b-b51a-f771cfc4bf00">
修改完之后更好看，更好用，因为现在的确选择yarn、pnpm的用户可能更多

<img width="1131" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/7316f546-783e-4768-8010-64d8006a3bee">
