### PR TITLE
chore: release 1.1.2

### DIFF
--- a/.changeset/eight-lizards-peel.md
+++ b/.changeset/eight-lizards-peel.md
@@ -1,6 +1,0 @@
----
-'@ant-design/web3-common': patch
-'@ant-design/web3': patch
----
-
-feat: ConnectModal support Intl

--- a/.changeset/gold-shrimps-buy.md
+++ b/.changeset/gold-shrimps-buy.md
@@ -1,9 +1,0 @@
----
-'@ant-design/web3-assets': patch
-'@ant-design/web3-common': patch
-'@ant-design/web3-icons': patch
-'@ant-design/web3-wagmi': patch
-'@ant-design/web3': patch
----
-
-fix: Improve the package.json information and add a main field to accommodate more projects.

--- a/.changeset/hip-seals-swim.md
+++ b/.changeset/hip-seals-swim.md
@@ -1,9 +1,0 @@
----
-'@ant-design/web3-assets': patch
-'@ant-design/web3-common': patch
-'@ant-design/web3-icons': patch
-'@ant-design/web3-wagmi': patch
-'@ant-design/web3': patch
----
-
-chore: 1.1.1

--- a/.changeset/hip-seals-swim.md
+++ b/.changeset/hip-seals-swim.md
@@ -1,0 +1,9 @@
+---
+'@ant-design/web3-assets': patch
+'@ant-design/web3-common': patch
+'@ant-design/web3-icons': patch
+'@ant-design/web3-wagmi': patch
+'@ant-design/web3': patch
+---
+
+chore: 1.1.1

--- a/.changeset/large-drinks-provide.md
+++ b/.changeset/large-drinks-provide.md
@@ -1,7 +1,0 @@
----
-'@ant-design/web3-assets': minor
-'@ant-design/web3-icons': minor
-'@ant-design/web3-wagmi': minor
----
-
-feat: add TokenPocket wallet icon and metadata

--- a/.changeset/large-drinks-provide.md
+++ b/.changeset/large-drinks-provide.md
@@ -1,5 +1,5 @@
 ---
-'@ant-design/web3-assets': major
+'@ant-design/web3-assets': minor
 '@ant-design/web3-icons': minor
 '@ant-design/web3-wagmi': minor
 ---

--- a/.changeset/long-cheetahs-film.md
+++ b/.changeset/long-cheetahs-film.md
@@ -1,0 +1,9 @@
+---
+'@ant-design/web3-assets': patch
+'@ant-design/web3-common': patch
+'@ant-design/web3-icons': patch
+'@ant-design/web3-wagmi': patch
+'@ant-design/web3': patch
+---
+
+chore: release 1.1.2 for republish

--- a/.changeset/long-cheetahs-film.md
+++ b/.changeset/long-cheetahs-film.md
@@ -1,9 +1,0 @@
----
-'@ant-design/web3-assets': patch
-'@ant-design/web3-common': patch
-'@ant-design/web3-icons': patch
-'@ant-design/web3-wagmi': patch
-'@ant-design/web3': patch
----
-
-chore: release 1.1.2 for republish

--- a/.changeset/metal-pots-jog.md
+++ b/.changeset/metal-pots-jog.md
@@ -1,8 +1,0 @@
----
-'@ant-design/web3-assets': minor
-'@ant-design/web3-icons': minor
-'@ant-design/web3-wagmi': minor
-'@ant-design/web3': minor
----
-
-feat: support safeheron browser wallet

--- a/.changeset/perfect-chefs-divide.md
+++ b/.changeset/perfect-chefs-divide.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-refactor: Update deprecated antd Modal props

--- a/.changeset/pink-yaks-check.md
+++ b/.changeset/pink-yaks-check.md
@@ -1,7 +1,0 @@
----
-'@ant-design/web3-common': minor
-'@ant-design/web3-wagmi': minor
-'@ant-design/web3': minor
----
-
-feat: ConnectButton support internationalization

--- a/.changeset/real-chefs-protect.md
+++ b/.changeset/real-chefs-protect.md
@@ -1,6 +1,0 @@
----
-'@ant-design/web3-common': patch
-'@ant-design/web3': patch
----
-
-feat: NFTCard support intl

--- a/.changeset/slimy-lamps-act.md
+++ b/.changeset/slimy-lamps-act.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-perf: use `??` Instead of `||`

--- a/.changeset/thirty-owls-destroy.md
+++ b/.changeset/thirty-owls-destroy.md
@@ -1,5 +1,5 @@
 ---
-'@ant-design/web3': major
+'@ant-design/web3': patch
 ---
 
 fix: debug connect-button ui

--- a/.changeset/thirty-owls-destroy.md
+++ b/.changeset/thirty-owls-destroy.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix: debug connect-button ui

--- a/.dumi/theme/builtins/IconSearch/fields.ts
+++ b/.dumi/theme/builtins/IconSearch/fields.ts
@@ -18,7 +18,14 @@ const chain = [
   'Avalanche',
 ];
 
-const tool = ['CoinbaseWallet', 'Etherscan', 'MetaMask', 'WalletConnect', 'TokenPocket', 'Safeheron'];
+const tool = [
+  'CoinbaseWallet',
+  'Etherscan',
+  'MetaMask',
+  'WalletConnect',
+  'TokenPocket',
+  'Safeheron',
+];
 
 const datum = [...chain, ...tool];
 

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @ant-design/web3-assets
 
+## 1.1.0
+
+### Minor Changes
+
+- b00a377: feat: add TokenPocket wallet icon and metadata
+- b3e95c2: feat: support safeheron browser wallet
+
+### Patch Changes
+
+- 69a3597: fix: Improve the package.json information and add a main field to accommodate more projects.
+- Updated dependencies [73e8e32]
+- Updated dependencies [69a3597]
+- Updated dependencies [b00a377]
+- Updated dependencies [b3e95c2]
+- Updated dependencies [3547f6b]
+- Updated dependencies [9de319c]
+  - @ant-design/web3-common@1.1.0
+  - @ant-design/web3-icons@1.1.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-assets
 
+## 1.1.1
+
+### Patch Changes
+
+- 32f276a: chore: 1.1.1
+- Updated dependencies [32f276a]
+  - @ant-design/web3-common@1.1.1
+  - @ant-design/web3-icons@1.1.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-assets
 
+## 1.1.2
+
+### Patch Changes
+
+- d6a5339: chore: release 1.1.2 for republish
+- Updated dependencies [d6a5339]
+  - @ant-design/web3-common@1.1.2
+  - @ant-design/web3-icons@1.1.2
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-assets",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-assets",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-assets",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ant-design/web3-common
 
+## 1.1.0
+
+### Minor Changes
+
+- 3547f6b: feat: ConnectButton support internationalization
+
+### Patch Changes
+
+- 73e8e32: feat: ConnectModal support Intl
+- 69a3597: fix: Improve the package.json information and add a main field to accommodate more projects.
+- 9de319c: feat: NFTCard support intl
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-common
 
+## 1.1.1
+
+### Patch Changes
+
+- 32f276a: chore: 1.1.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-common
 
+## 1.1.2
+
+### Patch Changes
+
+- d6a5339: chore: release 1.1.2 for republish
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-common",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-common",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-common",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-icons
 
+## 1.1.1
+
+### Patch Changes
+
+- 32f276a: chore: 1.1.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ant-design/web3-icons
 
+## 1.1.0
+
+### Minor Changes
+
+- b00a377: feat: add TokenPocket wallet icon and metadata
+- b3e95c2: feat: support safeheron browser wallet
+
+### Patch Changes
+
+- 69a3597: fix: Improve the package.json information and add a main field to accommodate more projects.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-icons
 
+## 1.1.2
+
+### Patch Changes
+
+- d6a5339: chore: release 1.1.2 for republish
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-icons",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-icons",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-icons",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/wagmi/CHANGELOG.md
+++ b/packages/wagmi/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-wagmi
 
+## 1.1.2
+
+### Patch Changes
+
+- d6a5339: chore: release 1.1.2 for republish
+- Updated dependencies [d6a5339]
+  - @ant-design/web3-assets@1.1.2
+  - @ant-design/web3-common@1.1.2
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wagmi/CHANGELOG.md
+++ b/packages/wagmi/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @ant-design/web3-wagmi
 
+## 1.1.0
+
+### Minor Changes
+
+- b00a377: feat: add TokenPocket wallet icon and metadata
+- b3e95c2: feat: support safeheron browser wallet
+- 3547f6b: feat: ConnectButton support internationalization
+
+### Patch Changes
+
+- 69a3597: fix: Improve the package.json information and add a main field to accommodate more projects.
+- Updated dependencies [73e8e32]
+- Updated dependencies [69a3597]
+- Updated dependencies [b00a377]
+- Updated dependencies [b3e95c2]
+- Updated dependencies [3547f6b]
+- Updated dependencies [9de319c]
+  - @ant-design/web3-common@1.1.0
+  - @ant-design/web3-assets@1.1.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/wagmi/CHANGELOG.md
+++ b/packages/wagmi/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-wagmi
 
+## 1.1.1
+
+### Patch Changes
+
+- 32f276a: chore: 1.1.1
+- Updated dependencies [32f276a]
+  - @ant-design/web3-assets@1.1.1
+  - @ant-design/web3-common@1.1.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-wagmi",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-wagmi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-wagmi",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3
 
+## 1.1.1
+
+### Patch Changes
+
+- 32f276a: chore: 1.1.1
+- Updated dependencies [32f276a]
+  - @ant-design/web3-assets@1.1.1
+  - @ant-design/web3-common@1.1.1
+  - @ant-design/web3-icons@1.1.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3
 
+## 1.1.2
+
+### Patch Changes
+
+- d6a5339: chore: release 1.1.2 for republish
+- Updated dependencies [d6a5339]
+  - @ant-design/web3-assets@1.1.2
+  - @ant-design/web3-common@1.1.2
+  - @ant-design/web3-icons@1.1.2
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @ant-design/web3
 
+## 1.1.0
+
+### Minor Changes
+
+- b3e95c2: feat: support safeheron browser wallet
+- 3547f6b: feat: ConnectButton support internationalization
+
+### Patch Changes
+
+- 73e8e32: feat: ConnectModal support Intl
+- 69a3597: fix: Improve the package.json information and add a main field to accommodate more projects.
+- f5a1b82: refactor: Update deprecated antd Modal props
+- 9de319c: feat: NFTCard support intl
+- f8dce24: perf: use `??` Instead of `||`
+- 13d0207: fix: debug connect-button ui
+- Updated dependencies [73e8e32]
+- Updated dependencies [69a3597]
+- Updated dependencies [b00a377]
+- Updated dependencies [b3e95c2]
+- Updated dependencies [3547f6b]
+- Updated dependencies [9de319c]
+  - @ant-design/web3-common@1.1.0
+  - @ant-design/web3-assets@1.1.0
+  - @ant-design/web3-icons@1.1.0
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",


### PR DESCRIPTION
1.1.0 and 1.1.1 因为之前有 PR 的 changlog 写成 major 了，发布的时候有错误，所以重新发布 1.1.2 成功，之前两个版本废弃。