### PR TITLE
ci(Changeset): auto add label

### DIFF
--- a/.changeset/tough-shirts-tan.md
+++ b/.changeset/tough-shirts-tan.md
@@ -1,5 +1,5 @@
 ---
-'@ant-design/web3-assets': patch
+'@ant-design/web3-assets': major
 '@ant-design/web3-common': patch
 '@ant-design/web3-wagmi': patch
 '@ant-design/web3-icons': patch

--- a/.changeset/tough-shirts-tan.md
+++ b/.changeset/tough-shirts-tan.md
@@ -1,6 +1,6 @@
 ---
-'@ant-design/web3-assets': major
-'@ant-design/web3-common': major
+'@ant-design/web3-assets': patch
+'@ant-design/web3-common': patch
 '@ant-design/web3-wagmi': patch
 '@ant-design/web3-icons': patch
 '@ant-design/web3': patch

--- a/.changeset/tough-shirts-tan.md
+++ b/.changeset/tough-shirts-tan.md
@@ -1,9 +1,0 @@
----
-'@ant-design/web3-assets': major
-'@ant-design/web3-common': patch
-'@ant-design/web3-wagmi': patch
-'@ant-design/web3-icons': patch
-'@ant-design/web3': patch
----
-
-chore: ONLY FOR CI TEST, DO NOT MERGE

--- a/.changeset/tough-shirts-tan.md
+++ b/.changeset/tough-shirts-tan.md
@@ -1,0 +1,9 @@
+---
+'@ant-design/web3-assets': major
+'@ant-design/web3-common': major
+'@ant-design/web3-wagmi': patch
+'@ant-design/web3-icons': patch
+'@ant-design/web3': patch
+---
+
+chore: ONLY FOR CI TEST, DO NOT MERGE

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -25,10 +25,6 @@ jobs:
         id: check_changeset
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ant-design
-          REPO: ant-design-web3
-          LABEL_NAME: major
         run: |
           files=$ALL_CHANGED_FILES
           echo "File list: $files"
@@ -36,18 +32,20 @@ jobs:
             major_changes=$(grep "major" $files)
             echo "Found major changes."
             echo "comment=$major_changes" >> $GITHUB_OUTPUT
-            gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${OWNER}/${REPO}/issues/${{ github.event.pull_request.number }}/labels" \
-            -f "labels[]=${LABEL_NAME}" \
-            -t "${{ secrets.GITHUB_TOKEN }}"
           else
             echo "Not found major changes."
             comment=""
             echo "comment=$comment" >> $GITHUB_OUTPUT
           fi
+
+      - name: Add label
+        if: ${{ steps.check_changeset.outputs.comment != '' }}
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'add-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'major'
 
       - name: update status comment
         if: ${{ steps.check_changeset.outputs.comment != '' }}
@@ -76,18 +74,11 @@ jobs:
             number: ${{ github.event.pull_request.number }}
             delete: true
 
-      - name: Delete label
+      - name: Remove labels
         if: ${{ steps.check_changeset.outputs.comment == '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ant-design
-          REPO: ant-design-web3
-          LABEL_NAME: major
-        run: |
-            echo "Deleting label..."
-            gh api \
-            --method DELETE \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${OWNER}/${REPO}/labels/${LABEL_NAME}" \
-            -t "${GITHUB_TOKEN}" || true
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'remove-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'major'

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -25,6 +25,10 @@ jobs:
         id: check_changeset
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ant-design
+          REPO: ant-design-web3
+          LABEL_NAME: major
         run: |
           files=$ALL_CHANGED_FILES
           echo "File list: $files"
@@ -32,6 +36,13 @@ jobs:
             major_changes=$(grep "major" $files)
             echo "Found major changes."
             echo "comment=$major_changes" >> $GITHUB_OUTPUT
+            gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${OWNER}/${REPO}/issues/${{ github.event.pull_request.number }}/labels" \
+            -f "labels[]=${LABEL_NAME}" \
+            -t "${{ secrets.GITHUB_TOKEN }}"
           else
             echo "Not found major changes."
             comment=""
@@ -64,3 +75,19 @@ jobs:
             body-include: '<!-- AUTO_CHANGESET_CHECK_HOOK -->'
             number: ${{ github.event.pull_request.number }}
             delete: true
+
+      - name: Delete label
+        if: ${{ steps.check_changeset.outputs.comment == '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ant-design
+          REPO: ant-design-web3
+          LABEL_NAME: major
+        run: |
+            echo "Deleting label..."
+            gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${OWNER}/${REPO}/labels/${LABEL_NAME}" \
+            -t "${GITHUB_TOKEN}" || true


### PR DESCRIPTION
好像还缺少一些权限

接口文档: https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28

<img width="1190" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/79e7a9e7-1e31-4297-b3c9-0175ce94252f">

# 我用自己的账号写了个demo
https://github.com/thinkasany/PR-template/pull/1
## add label
<img width="913" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/b22000e4-4055-4958-ac15-2ffe7faaa652">

## remove label
<img width="1155" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/70c26c4a-6be2-4705-8d0b-d7a2c964b81e">


# 详细ci流程
## add label
<img width="687" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/542595ab-5fba-4f28-bc26-9ac1670ba9fa">

## remove label
<img width="933" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/75639051-4dc3-43ec-8266-3c9175b0e14a">

