### PR TITLE
Copy address to try a more internationalized interaction

### DIFF
--- a/.changeset/nice-items-search.md
+++ b/.changeset/nice-items-search.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': minor
+---
+
+feat: Copy address to try a more internationalized interaction.

--- a/packages/web3/src/address/__tests__/index.test.tsx
+++ b/packages/web3/src/address/__tests__/index.test.tsx
@@ -89,8 +89,8 @@ describe('Address', () => {
     expect(baseElement.querySelector('.ant-web3-address')?.textContent).toBe('0x21CD...Fd3B');
     fireEvent.click(baseElement.querySelector('.anticon-copy')!);
     await vi.waitFor(() => {
-      expect(baseElement.querySelector('.ant-message')).not.toBeNull();
-      expect(baseElement.querySelector('.ant-message-notice-content')?.textContent?.trim()).toBe(
+      expect(baseElement.querySelector('.anticon-check')).not.toBeNull();
+      expect(baseElement.querySelector('.anticon-check')?.getAttribute('title')).toBe(
         'Address Copied!',
       );
       expect(readCopyText()).resolves.toBe('0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B');

--- a/packages/web3/src/address/__tests__/index.test.tsx
+++ b/packages/web3/src/address/__tests__/index.test.tsx
@@ -9,9 +9,12 @@ describe('Address', () => {
   let resetMockClipboard: () => void;
   beforeEach(() => {
     resetMockClipboard = mockClipboard();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
   afterEach(() => {
     resetMockClipboard();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
   });
 
   it('mount correctly', () => {
@@ -88,8 +91,9 @@ describe('Address', () => {
     );
     expect(baseElement.querySelector('.ant-web3-address')?.textContent).toBe('0x21CD...Fd3B');
     fireEvent.click(baseElement.querySelector('.anticon-copy')!);
-    await vi.waitFor(() => {
+    await vi.waitFor(async () => {
       expect(baseElement.querySelector('.anticon-check')).not.toBeNull();
+      expect(baseElement.querySelector('.anticon-copy')).toBeNull();
       expect(baseElement.querySelector('.anticon-check')?.getAttribute('title')).toBe(
         'Address Copied!',
       );
@@ -120,5 +124,15 @@ describe('Address', () => {
     expect(baseElement.querySelector('.ant-web3-address')?.textContent).toBe(
       '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B',
     );
+  });
+
+  it('should show copy icon after 2s', async () => {
+    const { baseElement } = render(
+      <Address address="0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B" copyable />,
+    );
+    fireEvent.click(baseElement.querySelector('.anticon-copy')!);
+    vi.advanceTimersByTime(2000);
+    expect(baseElement.querySelector('.anticon-check')).toBeNull();
+    expect(baseElement.querySelector('.anticon-copy')).not.toBeNull();
   });
 });

--- a/packages/web3/src/address/index.tsx
+++ b/packages/web3/src/address/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { CheckOutlined, CopyOutlined } from '@ant-design/icons';
 import type { TooltipProps } from 'antd';
 import { ConfigProvider, Space, Tooltip } from 'antd';
@@ -27,6 +27,7 @@ export const Address: React.FC<React.PropsWithChildren<AddressProps>> = (props) 
   const prefixCls = getPrefixCls('web3-address');
   const { wrapSSR, hashId } = useStyle(prefixCls);
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
 
   const mergedFormat = useMemo(() => {
     if (typeof format === 'function') {
@@ -46,6 +47,14 @@ export const Address: React.FC<React.PropsWithChildren<AddressProps>> = (props) 
           tailClip: 4,
         }
       : ellipsis;
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
 
   if (!address) {
     return null;
@@ -76,7 +85,7 @@ export const Address: React.FC<React.PropsWithChildren<AddressProps>> = (props) 
               onClick={() => {
                 writeCopyText(filledAddress).then(() => {
                   setCopied(true);
-                  setTimeout(() => {
+                  timerRef.current = setTimeout(() => {
                     setCopied(false);
                   }, 2000);
                 });

--- a/packages/web3/src/address/index.tsx
+++ b/packages/web3/src/address/index.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
-import React, { useContext, useMemo } from 'react';
-import { CopyOutlined } from '@ant-design/icons';
+import React, { useContext, useMemo, useState } from 'react';
+import { CheckOutlined, CopyOutlined } from '@ant-design/icons';
 import type { TooltipProps } from 'antd';
-import { ConfigProvider, message, Space, Tooltip } from 'antd';
+import { ConfigProvider, Space, Tooltip } from 'antd';
 import classNames from 'classnames';
 
 import { fillWith0x, formatAddress, writeCopyText } from '../utils';
@@ -23,10 +23,10 @@ export interface AddressProps {
 
 export const Address: React.FC<React.PropsWithChildren<AddressProps>> = (props) => {
   const { ellipsis, address, copyable, tooltip, format = false, children } = props;
-  const [messageApi, contextHolder] = message.useMessage();
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const prefixCls = getPrefixCls('web3-address');
   const { wrapSSR, hashId } = useStyle(prefixCls);
+  const [copied, setCopied] = useState(false);
 
   const mergedFormat = useMemo(() => {
     if (typeof format === 'function') {
@@ -57,28 +57,34 @@ export const Address: React.FC<React.PropsWithChildren<AddressProps>> = (props) 
   const displayTooltip = tooltip === undefined || tooltip === true ? filledAddress : tooltip;
 
   return wrapSSR(
-    <>
-      {contextHolder}
-      <Space className={classNames(prefixCls, hashId)}>
-        <Tooltip title={displayTooltip}>
-          <span className={`${prefixCls}-text`}>
-            {children ??
-              (isEllipsis
-                ? `${filledAddress.slice(0, headClip)}...${filledAddress.slice(-tailClip)}`
-                : formattedAddress)}
-          </span>
-        </Tooltip>
-        {copyable && (
-          <CopyOutlined
-            title="Copy Address"
-            onClick={() => {
-              writeCopyText(filledAddress).then(() => {
-                messageApi.success('Address Copied!');
-              });
-            }}
-          />
-        )}
-      </Space>
-    </>,
+    <Space className={classNames(prefixCls, hashId)}>
+      <Tooltip title={displayTooltip}>
+        <span className={`${prefixCls}-text`}>
+          {children ??
+            (isEllipsis
+              ? `${filledAddress.slice(0, headClip)}...${filledAddress.slice(-tailClip)}`
+              : formattedAddress)}
+        </span>
+      </Tooltip>
+      {copyable && (
+        <>
+          {copied ? (
+            <CheckOutlined title="Address Copied!" />
+          ) : (
+            <CopyOutlined
+              title="Copy Address"
+              onClick={() => {
+                writeCopyText(filledAddress).then(() => {
+                  setCopied(true);
+                  setTimeout(() => {
+                    setCopied(false);
+                  }, 2000);
+                });
+              }}
+            />
+          )}
+        </>
+      )}
+    </Space>,
   );
 };

--- a/packages/web3/src/hooks/demos/useConnection.tsx
+++ b/packages/web3/src/hooks/demos/useConnection.tsx
@@ -6,18 +6,21 @@ const Demo: React.FC = () => {
   const { account } = useAccount();
   const { connect, disconnect } = useConnection();
   return (
-    <Button
-      onClick={() => {
-        if (account) {
-          disconnect?.();
-        } else {
-          console.log('connect');
-          connect?.();
-        }
-      }}
-    >
-      {account ? 'Disconnect' : 'Connect'}
-    </Button>
+    <>
+      <Button
+        onClick={() => {
+          if (account) {
+            disconnect?.();
+          } else {
+            console.log('connect');
+            connect?.();
+          }
+        }}
+      >
+        {account ? 'Disconnect' : 'Connect'}
+      </Button>
+      {account ? <p>Account: {account?.address}</p> : <p>Not Connected</p>}
+    </>
   );
 };
 


### PR DESCRIPTION
Updates:

1. Update the copy address feature to incorporate a more internationalized interaction. For example, some leading web3 companies include openzeppelin.com 、consensys.io、etherscan.io and others.
2. Provide feedback in the connectwallet example after providing the link, as the Metamask pop-up won't appear when connecting again.