### PR TITLE
docs: update docs about changeset

### DIFF
--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -13,7 +13,7 @@ All work on Ant Design Web3 happens directly on [GitHub](https://github.com/ant-
 
 ## How to Contribute
 
-**When submitting a PR, please execute `pnpm changeset` to generate the changelog first, and then submit the PR.** We manage version releases through [changesets](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md). Executing this command will generate changelog files under `.changeset`, and these files will be automatically merged into `CHANGELOG.md` when released. But not every PR needs a changelog, for example, PRs that do not involve package content modifications such as documents and official websites do not need to execute this command.
+**When submitting a PR, please execute `pnpm changeset` to generate the changelog first, and then submit the PR.** We manage version releases through [changesets](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md). Executing this command will generate changelog files under `.changeset`, and these files will be automatically merged into `CHANGELOG.md` when released. But not every PR needs a changelog, for example, PRs that do not involve package content modifications such as documents and official websites do not need to execute this command. For more changesets usage guide, please refer to: [adding-a-changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
 
 ### Contribute Code
 

--- a/docs/guide/contributing.zh-CN.md
+++ b/docs/guide/contributing.zh-CN.md
@@ -13,7 +13,7 @@ group:
 
 ## 如何贡献
 
-**提交 PR 时请先执行 `pnpm changeset` 生成变更说明，然后再提交 PR。** 我们通过 [changesets](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md) 管理版本发布，执行该命令会在 `.changeset` 下生成变更说明文件，这些文件会在发布时自动合并到 `CHANGELOG.md` 中。但是并不是每个 PR 都需要变更说明，比如文档、官网等不涉及到包内容修改的 PR，可以不用执行该命令。
+**提交 PR 时请先执行 `pnpm changeset` 生成变更说明，然后再提交 PR。** 我们通过 [changesets](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md) 管理版本发布，执行该命令会在 `.changeset` 下生成变更说明文件，这些文件会在发布时自动合并到 `CHANGELOG.md` 中。但是并不是每个 PR 都需要变更说明，比如文档、官网等不涉及到包内容修改的 PR，可以不用执行该命令。更多 changesets 的使用指南详见：[adding-a-changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)。
 
 ### 贡献代码
 


### PR DESCRIPTION
Some contributors have not used changeset before, and it is easy to misoperate when operating. Add changeset's new changelog user guide link.