### PR TITLE
docs: opt connect-button docs

### DIFF
--- a/packages/web3/src/connect-button/index.md
+++ b/packages/web3/src/connect-button/index.md
@@ -46,7 +46,7 @@ The button to connect to the blockchain wallet. Usually, you need to use it with
 
 <code src="./demos/icon.tsx"></code>
 
-## Balance
+## Display Balance
 
 <code src="./demos/balance.tsx"></code>
 

--- a/packages/web3/src/wagmi/index.md
+++ b/packages/web3/src/wagmi/index.md
@@ -43,7 +43,7 @@ We have built-in `Mainnet` and `Goerli`, and the remaining chains need to config
 
 <code src="./demos/name.tsx"></code>
 
-## Display balance
+## Display Balance
 
 <code src="./demos/balance.tsx"></code>
 


### PR DESCRIPTION
重命名示例标题，避免跟后面的 Balance 的 API 表格命名冲突跳转异常