### PR TITLE
chore: opt connect-button's combinedItems

### DIFF
--- a/packages/web3/src/connect-button/connect-button.tsx
+++ b/packages/web3/src/connect-button/connect-button.tsx
@@ -187,10 +187,8 @@ export const ConnectButton: React.FC<ConnectButtonProps> = (props) => {
 
     const combinedItems = account
       ? actionsMenu.extraItems
-        ? [...actionsMenu.extraItems, ...(account ? defaultMenuItems : [])]
-        : account
-          ? defaultMenuItems
-          : []
+        ? [...actionsMenu.extraItems, ...defaultMenuItems]
+        : defaultMenuItems
       : actionsMenu.extraItems || [];
 
     return combinedItems;


### PR DESCRIPTION
这边 account不存在的话都直接返回下面actionsMenu了，所以可以直接用defaultMenuItems没必要再套一个account的 三元

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/e83c7a80-4989-4bde-9a6a-2280b0b239e4)
