### PR TITLE
fix: fix intl for connect-button

### DIFF
--- a/.changeset/shy-rice-smash.md
+++ b/.changeset/shy-rice-smash.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix: fix intl for connect-button

--- a/packages/web3/src/connect-button/connect-button.tsx
+++ b/packages/web3/src/connect-button/connect-button.tsx
@@ -147,7 +147,7 @@ export const ConnectButton: React.FC<ConnectButtonProps> = (props) => {
   const defaultMenuItems: MenuItemType[] = useMemo(
     () => [
       {
-        label: 'Copy Address',
+        label: intl.getMessage(intl.messages.copyAddress),
         key: 'copyAddress',
         onClick: () => {
           setProfileOpen(false);


### PR DESCRIPTION
locale为中文时，`Copy Address` 显示英文。
![image](https://github.com/ant-design/ant-design-web3/assets/73225408/677b60c4-e24d-46ee-adce-4d80ff7ef366)
