### PR TITLE
feat: support eip6963

### DIFF
--- a/.changeset/lucky-suns-perform.md
+++ b/.changeset/lucky-suns-perform.md
@@ -1,0 +1,6 @@
+---
+'@ant-design/web3-wagmi': minor
+'@ant-design/web3': minor
+---
+
+feat: support EIP6963 wallet

--- a/packages/wagmi/src/utils.ts
+++ b/packages/wagmi/src/utils.ts
@@ -1,7 +1,16 @@
 import debug from 'debug';
+import type { Connector as WagmiConnector } from 'wagmi';
+import { injected } from 'wagmi/connectors';
 
 const createDebug = (namespace: string) => {
   return debug(`antd-web3:wagmi:${namespace}`);
 };
 
-export { createDebug };
+const isEIP6963Connector = (connector: WagmiConnector) => {
+  if (connector.type === injected.type && connector.icon && connector.id && connector.name) {
+    return true;
+  }
+  return false;
+};
+
+export { createDebug, isEIP6963Connector };

--- a/packages/wagmi/src/wagmi-provider/__tests__/config-with-eip6963-wallet.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/config-with-eip6963-wallet.test.tsx
@@ -1,0 +1,138 @@
+import { ConnectButton, Connector } from '@ant-design/web3';
+import { EIP6963Wallet, WagmiWeb3ConfigProvider } from '@ant-design/web3-wagmi';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createConfig, http } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
+import { injected } from 'wagmi/connectors';
+
+const mockConnectAsync = vi.fn();
+
+describe('WagmiWeb3ConfigProvider with EIP6963 Wallet', () => {
+  it('Should correctly show all wallets discovered via EIP6963', () => {
+    const target1 = {
+      icon: 'icon1',
+      id: 'com.mock.wallet1',
+      name: 'mockWallet1',
+      provider: undefined as any,
+    };
+
+    const target2 = {
+      icon: 'icon2',
+      id: 'com.mock.wallet2',
+      name: 'mockWallet2',
+      provider: undefined as any,
+    };
+
+    const mockDiscoveredConnectorsViaEIP6963 = [
+      injected({
+        target: target1,
+      }),
+      injected({
+        target: target2,
+      }),
+    ];
+
+    const groupName = 'eip6963';
+
+    const config = createConfig({
+      chains: [mainnet],
+      transports: {
+        [mainnet.id]: http(),
+      },
+      connectors: mockDiscoveredConnectorsViaEIP6963,
+    });
+
+    const App = () => (
+      <WagmiWeb3ConfigProvider
+        wallets={[
+          EIP6963Wallet({
+            group: groupName,
+          }),
+        ]}
+        config={config}
+      >
+        <Connector>
+          <ConnectButton />
+        </Connector>
+      </WagmiWeb3ConfigProvider>
+    );
+    const { baseElement } = render(<App />);
+    const btn = baseElement.querySelector('.ant-web3-connect-button');
+    fireEvent.click(btn!);
+    const walletItems = baseElement.querySelectorAll('.ant-web3-connect-modal-wallet-item');
+    expect(walletItems.length).toBe(mockDiscoveredConnectorsViaEIP6963.length);
+    expect(walletItems[0].querySelector('.ant-web3-connect-modal-name')?.textContent).toBe(
+      target1.name,
+    );
+    expect(walletItems[1].querySelector('.ant-web3-connect-modal-name')?.textContent).toBe(
+      target2.name,
+    );
+    expect(
+      walletItems[0].querySelector('.ant-web3-connect-modal-icon > img')?.getAttribute('src'),
+    ).toBe(target1.icon);
+    expect(
+      walletItems[1].querySelector('.ant-web3-connect-modal-icon > img')?.getAttribute('src'),
+    ).toBe(target2.icon);
+    const groupTitle = baseElement.querySelector('.ant-web3-connect-modal-group-title');
+    expect(groupTitle?.textContent).toBe(groupName);
+  });
+
+  it('Should correctly connect the selected wallet', async () => {
+    vi.mock('wagmi', async () => {
+      const actual = await vi.importActual('wagmi');
+      return {
+        ...actual,
+        useConnect: () => {
+          return {
+            connectAsync: async (...args: any[]) => {
+              mockConnectAsync(...args);
+            },
+          };
+        },
+      };
+    });
+    const target = {
+      icon: 'icon1',
+      id: 'com.mock.wallet1',
+      name: 'mockWallet1',
+      provider: {
+        request: () => {},
+        on: () => {},
+      } as any,
+    };
+
+    const mockDiscoveredConnectorsViaEIP6963 = [
+      injected({
+        target,
+      }),
+    ];
+
+    const config = createConfig({
+      chains: [mainnet],
+      transports: {
+        [mainnet.id]: http(),
+      },
+      connectors: mockDiscoveredConnectorsViaEIP6963,
+    });
+
+    const App = () => (
+      <WagmiWeb3ConfigProvider wallets={[EIP6963Wallet()]} config={config}>
+        <Connector>
+          <ConnectButton />
+        </Connector>
+      </WagmiWeb3ConfigProvider>
+    );
+    const { baseElement } = render(<App />);
+    const btn = baseElement.querySelector('.ant-web3-connect-button');
+    fireEvent.click(btn!);
+    const walletItem = baseElement.querySelector('.ant-web3-connect-modal-wallet-item');
+    fireEvent.click(walletItem!);
+    await vi.waitFor(() => {
+      expect(mockConnectAsync).toHaveBeenCalledWith({
+        connector: config.connectors[0],
+        chainId: config.chains[0].id,
+      });
+    });
+  });
+});

--- a/packages/wagmi/src/wallets/__tests__/eip6963.test.tsx
+++ b/packages/wagmi/src/wallets/__tests__/eip6963.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { createConfig, http } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
+import { injected } from 'wagmi/connectors';
+
+import { EIP6963Wallet } from '../eip6963';
+
+describe('EIP6963', () => {
+  it("The wallet's metadata should match the connector's metadata", async () => {
+    const config = createConfig({
+      chains: [mainnet],
+      transports: {
+        [mainnet.id]: http(),
+      },
+      connectors: [
+        injected({
+          target() {
+            return {
+              icon: 'mockIconData',
+              id: 'com.mock.wallet',
+              name: 'mockWallet',
+              provider: undefined as any,
+            };
+          },
+        }),
+      ],
+    });
+    const wallet = EIP6963Wallet().create(config.connectors);
+    const connector = config.connectors[0];
+    expect(wallet.icon).toBe(connector.icon);
+    expect(wallet.name).toBe(connector.name);
+    expect(wallet.remark).toBe(connector.name);
+    expect(wallet.key).toBe(connector.id);
+  });
+
+  it('provider is ready', async () => {
+    const config = createConfig({
+      chains: [mainnet],
+      transports: {
+        [mainnet.id]: http(),
+      },
+      connectors: [
+        injected({
+          target() {
+            return {
+              icon: 'mockIconData',
+              id: 'com.mock.wallet',
+              name: 'mockWallet',
+              provider: {
+                request: () => {},
+                on: () => {},
+              } as any,
+            };
+          },
+        }),
+      ],
+    });
+    const wallet = EIP6963Wallet().create(config.connectors);
+    await expect(wallet.hasWalletReady?.()).resolves.toBe(true);
+    await expect(wallet.hasExtensionInstalled?.()).resolves.toBe(true);
+  });
+
+  it('provider not ready', async () => {
+    const config = createConfig({
+      chains: [mainnet],
+      transports: {
+        [mainnet.id]: http(),
+      },
+      connectors: [
+        injected({
+          target() {
+            return {
+              icon: 'mockIconData',
+              id: 'com.mock.wallet',
+              name: 'mockWallet',
+              provider: undefined as any,
+            };
+          },
+        }),
+      ],
+    });
+    const wallet = EIP6963Wallet().create(config.connectors);
+    await expect(wallet.hasWalletReady?.()).resolves.toBe(false);
+    await expect(wallet.hasExtensionInstalled?.()).resolves.toBe(false);
+  });
+
+  it('custom metadata', () => {
+    const config = createConfig({
+      chains: [mainnet],
+      transports: {
+        [mainnet.id]: http(),
+      },
+      connectors: [
+        injected({
+          target() {
+            return {
+              icon: 'mockIconData',
+              id: 'com.mock.wallet',
+              name: 'mockWallet',
+              provider: undefined as any,
+            };
+          },
+        }),
+      ],
+    });
+    const wallet = EIP6963Wallet({
+      group: 'TestGroup',
+    }).create(config.connectors);
+    expect(wallet.group).toBe('TestGroup');
+  });
+});

--- a/packages/wagmi/src/wallets/eip6963.tsx
+++ b/packages/wagmi/src/wallets/eip6963.tsx
@@ -1,0 +1,31 @@
+import type { Wallet, WalletMetadata } from '@ant-design/web3-common';
+import type { Connector } from 'wagmi';
+
+import type { EthereumWallet } from '../interface';
+
+export const EIP6963_CONNECTOR = 'EIP6963';
+
+export const EIP6963Wallet: EthereumWallet = (metadata) => {
+  return {
+    connectors: [EIP6963_CONNECTOR],
+    create: (connectors?: readonly Connector[]): Wallet => {
+      const connector = connectors?.[0];
+      const metadata_eip6963: WalletMetadata = {
+        icon: connector?.icon,
+        name: connector!.name,
+        remark: connector!.name,
+        key: connector?.id,
+      };
+      return {
+        ...metadata_eip6963,
+        hasWalletReady: async () => {
+          return !!(await connector?.getProvider());
+        },
+        hasExtensionInstalled: async () => {
+          return !!(await connector?.getProvider());
+        },
+        ...metadata,
+      };
+    },
+  };
+};

--- a/packages/wagmi/src/wallets/index.ts
+++ b/packages/wagmi/src/wallets/index.ts
@@ -1,3 +1,4 @@
+export * from './eip6963';
 export * from './meta-mask';
 export * from './wallet-connect';
 export * from './coinbase-wallet';

--- a/packages/web3/src/wagmi/demos/more-wallets.tsx
+++ b/packages/web3/src/wagmi/demos/more-wallets.tsx
@@ -1,6 +1,7 @@
 import { ConnectButton, Connector } from '@ant-design/web3';
 import {
   CoinbaseWallet,
+  EIP6963Wallet,
   MetaMask,
   SafeheronWallet,
   TokenPocket,
@@ -55,6 +56,9 @@ const App: React.FC = () => {
         }),
         CoinbaseWallet(),
         SafeheronWallet(),
+        EIP6963Wallet({
+          group: 'EIP6963',
+        }),
       ]}
       config={config}
     >


### PR DESCRIPTION
I noticed that wagmi was recently upgraded to wagmi@2, so I submitted this PR.
This PR would support having the modal display all browser wallets that support [EIP6963](https://eips.ethereum.org/EIPS/eip-6963), even if `ant-design-web3` doesn't have the corresponding wallet metadata built in!
For example: safeheron, okx wallet, bitget wallet, brave, rainbow and so on. 
More EIP6963 wallets can be found at https://github.com/WalletConnect/EIP6963/blob/master/src/utils/constants.ts