### PR TITLE
fix: add exports field for fix require bug in nextjs

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -4,6 +4,11 @@
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/lib/index.js",
+    "types": "./dist/esm/index.d.ts"
+  },
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,6 +4,11 @@
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/lib/index.js",
+    "types": "./dist/esm/index.d.ts"
+  },
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -4,6 +4,11 @@
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/lib/index.js",
+    "types": "./dist/esm/index.d.ts"
+  },
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -4,6 +4,11 @@
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/lib/index.js",
+    "types": "./dist/esm/index.d.ts"
+  },
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -4,6 +4,11 @@
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/lib/index.js",
+    "types": "./dist/esm/index.d.ts"
+  },
   "files": [
     "dist",
     "CHANGELOG.md",


### PR DESCRIPTION
Add a more advanced `exports` field to better adapt to Next.js. Otherwise, Next.js will default to importing the resource corresponding to the `main` field, resulting in the following error:

![image](https://github.com/ant-design/ant-design-web3/assets/1061968/566910c6-cd5b-4a24-9971-d8d8cea1fd26)
