### PR TITLE
fix: Profile Modal lack space

### DIFF
--- a/.changeset/eleven-eagles-deliver.md
+++ b/.changeset/eleven-eagles-deliver.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix: Profile Modal lack space

--- a/packages/web3/src/connect-button/style/index.ts
+++ b/packages/web3/src/connect-button/style/index.ts
@@ -69,6 +69,9 @@ const genConnectButtonStyle: GenerateStyle<ConnectButtonToken> = (token) => {
         [`${token.antCls}-btn`]: {
           flex: 1,
         },
+        [`> ${token.antCls}-btn + ${token.antCls}-btn`]: {
+          marginInlineStart: token.marginXS,
+        },
       },
       [`&-name`]: {
         color: token.colorTextHeading,

--- a/packages/web3/src/connect-button/style/index.ts
+++ b/packages/web3/src/connect-button/style/index.ts
@@ -66,11 +66,9 @@ const genConnectButtonStyle: GenerateStyle<ConnectButtonToken> = (token) => {
       [`&-footer`]: {
         display: 'flex',
         marginTop: token.margin,
+        gap: token.marginXS,
         [`${token.antCls}-btn`]: {
           flex: 1,
-        },
-        [`> ${token.antCls}-btn + ${token.antCls}-btn`]: {
-          marginInlineStart: token.marginXS,
         },
       },
       [`&-name`]: {


### PR DESCRIPTION
#511 
demo 缺少`margin-inline-start: 8px;`
<img width="924" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/6c316638-8f09-4113-a93a-ae947528245c">

<img width="925" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/f3b9f5a5-fee0-4c31-ba31-74cdcfc7587a">
