### PR TITLE
fix: use esm import as the default import way for fix use in Remix

### DIFF
--- a/.changeset/rare-items-roll.md
+++ b/.changeset/rare-items-roll.md
@@ -1,0 +1,9 @@
+---
+'@ant-design/web3-assets': patch
+'@ant-design/web3-common': patch
+'@ant-design/web3-icons': patch
+'@ant-design/web3-wagmi': patch
+'@ant-design/web3': patch
+---
+
+fix: use esm import as the default import way for fix use in Remix and NextJS

--- a/.fatherrc.base.ts
+++ b/.fatherrc.base.ts
@@ -31,5 +31,7 @@ export default defineConfig({
         },
       },
     ],
+    // Auto add .js extension for import in node environment when use with NextJS and Remix.
+    'babel-plugin-add-import-extension',
   ],
 });

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@changesets/changelog-git": "^0.2.0",
     "@changesets/cli": "^2.27.1",
     "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
+    "@tanstack/react-query": "^5.17.0",
     "@testing-library/react": "^14.1.2",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.10.5",
@@ -64,6 +65,8 @@
     "@vitest/coverage-v8": "^1.1.0",
     "antd": "^5.12.4",
     "antd-style": "^3.6.1",
+    "babel-plugin-add-import-extension": "^1.6.0",
+    "babel-plugin-inline-react-svg": "^2.0.2",
     "classnames": "^2.3.2",
     "dumi": "^2.2.16",
     "eslint": "^8.56.0",
@@ -80,11 +83,10 @@
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",
     "typescript": "^5.3.3",
+    "viem": "^2.0.0",
     "vite-plugin-svgr": "^4.2.0",
     "vitest": "~1.1.0",
-    "wagmi": "^2.0.0",
-    "viem": "^2.0.0",
-    "@tanstack/react-query": "^5.17.0"
+    "wagmi": "^2.0.0"
   },
   "ci": {
     "type": "aci",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ant-design/web3-assets",
   "version": "1.2.1",
-  "main": "dist/lib/index.js",
+  "type": "module",
+  "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
   "exports": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -40,12 +40,11 @@
     "build": "father build"
   },
   "dependencies": {
-    "lodash.merge": "^4.6.2"
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
-    "@types/lodash.merge": "^4.6.9",
     "antd": "^5.12.4",
     "father": "^4.3.8",
     "react": "^18.2.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -40,11 +40,12 @@
     "build": "father build"
   },
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
+    "@types/lodash.merge": "^4.6.9",
     "antd": "^5.12.4",
     "father": "^4.3.8",
     "react": "^18.2.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
+    "@types/lodash-es": "^4.17.12",
     "antd": "^5.12.4",
     "father": "^4.3.8",
     "react": "^18.2.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ant-design/web3-common",
   "version": "1.3.2",
-  "main": "dist/lib/index.js",
+  "type": "module",
+  "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
   "exports": {

--- a/packages/common/src/web3-config-provider/index.tsx
+++ b/packages/common/src/web3-config-provider/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { merge } from 'lodash';
+import merge from 'lodash.merge';
 
 import defaultLocale from '../locale/default';
 import { ConfigContext, type ConfigConsumerProps, type Web3ConfigProviderProps } from './context';

--- a/packages/common/src/web3-config-provider/index.tsx
+++ b/packages/common/src/web3-config-provider/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import merge from 'lodash.merge';
+import { merge } from 'lodash-es';
 
 import defaultLocale from '../locale/default';
 import { ConfigContext, type ConfigConsumerProps, type Web3ConfigProviderProps } from './context';

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ant-design/web3-icons",
   "version": "1.3.1",
-  "main": "dist/lib/index.js",
+  "type": "module",
+  "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
   "exports": {
@@ -42,7 +43,6 @@
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "antd": "^5.12.4",
-    "babel-plugin-inline-react-svg": "^2.0.2",
     "father": "^4.3.8",
     "glob": "^10.3.10",
     "react": "^18.2.0",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ant-design/web3-wagmi",
   "version": "2.2.1",
-  "main": "dist/lib/index.js",
+  "type": "module",
+  "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
   "exports": {

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ant-design/web3",
   "version": "1.4.0",
-  "main": "dist/lib/index.js",
+  "type": "module",
+  "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
     devDependencies:
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/react':
         specifier: ^18.2.45
         version: 18.2.45
@@ -5275,6 +5278,12 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 20.10.5
+    dev: true
+
+  /@types/lodash-es@4.17.12:
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+    dependencies:
+      '@types/lodash': 4.14.202
     dev: true
 
   /@types/lodash@4.14.202:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,13 +165,10 @@ importers:
 
   packages/common:
     dependencies:
-      lodash.merge:
-        specifier: ^4.6.2
-        version: 4.6.2
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
-      '@types/lodash.merge':
-        specifier: ^4.6.9
-        version: 4.6.9
       '@types/react':
         specifier: ^18.2.45
         version: 18.2.45
@@ -5278,12 +5275,6 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 20.10.5
-    dev: true
-
-  /@types/lodash.merge@4.6.9:
-    resolution: {integrity: sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==}
-    dependencies:
-      '@types/lodash': 4.14.202
     dev: true
 
   /@types/lodash@4.14.202:
@@ -12757,6 +12748,10 @@ packages:
     dependencies:
       p-locate: 5.0.0
 
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
+
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -12779,6 +12774,7 @@ packages:
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
 
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,10 +165,13 @@ importers:
 
   packages/common:
     dependencies:
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
+      lodash.merge:
+        specifier: ^4.6.2
+        version: 4.6.2
     devDependencies:
+      '@types/lodash.merge':
+        specifier: ^4.6.9
+        version: 4.6.9
       '@types/react':
         specifier: ^18.2.45
         version: 18.2.45
@@ -5275,6 +5278,12 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 20.10.5
+    dev: true
+
+  /@types/lodash.merge@4.6.9:
+    resolution: {integrity: sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==}
+    dependencies:
+      '@types/lodash': 4.14.202
     dev: true
 
   /@types/lodash@4.14.202:
@@ -12770,7 +12779,6 @@ packages:
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: true
 
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -12785,6 +12793,7 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
 
   /log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,12 @@ importers:
       antd-style:
         specifier: ^3.6.1
         version: 3.6.1(@types/react@18.2.45)(antd@5.12.4)(react-dom@18.2.0)(react@18.2.0)
+      babel-plugin-add-import-extension:
+        specifier: ^1.6.0
+        version: 1.6.0(@babel/core@7.23.6)
+      babel-plugin-inline-react-svg:
+        specifier: ^2.0.2
+        version: 2.0.2(@babel/core@7.23.6)
       classnames:
         specifier: ^2.3.2
         version: 2.3.2
@@ -203,9 +209,6 @@ importers:
       antd:
         specifier: ^5.12.4
         version: 5.12.4(react-dom@18.2.0)(react@18.2.0)
-      babel-plugin-inline-react-svg:
-        specifier: ^2.0.2
-        version: 2.0.2(@babel/core@7.23.6)
       father:
         specifier: ^4.3.8
         version: 4.3.8(@types/node@20.10.5)(webpack@5.89.0)
@@ -7216,6 +7219,15 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-add-import-extension@1.6.0(@babel/core@7.23.6):
+    resolution: {integrity: sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+    dependencies:
+      '@babel/core': 7.23.6
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /babel-plugin-dynamic-import-node@2.3.3:
     resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
     dependencies:
@@ -8624,7 +8636,7 @@ packages:
     dev: true
 
   /debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==, tarball: https://registry.npmmirror.com/debug/-/debug-3.2.7.tgz}
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:


### PR DESCRIPTION
- ESM 现在应该是更主流更新更流行的打包方式了，`main` 字段默认改为 esm 的，对应 `type` 也修改为 `module`，这样在大部分框架中得以更好的默认支持。在 NextJS 和 Remix 中都是如此。可以 close #519 
- 默认添加 `.js` 的后缀，不然在 NexJS 和 Remix 这样可能在 NodeJS 环境运行 esm 的框架中会报找不到模块。