### PR TITLE
test: Increase ConnectModal's components test coverage

### DIFF
--- a/.changeset/tender-buckets-peel.md
+++ b/.changeset/tender-buckets-peel.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-test: Increase ConnectModal's components test coverage

--- a/.changeset/tender-buckets-peel.md
+++ b/.changeset/tender-buckets-peel.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+test: Increase ConnectModal's components test coverage

--- a/packages/web3/src/connect-modal/__tests__/MainPanelHeader.test.tsx
+++ b/packages/web3/src/connect-modal/__tests__/MainPanelHeader.test.tsx
@@ -14,7 +14,14 @@ describe('MainPanelHeader test', async () => {
     });
 
     const App = () => {
-      const { prefixCls } = useContext(connectModalContext);
+      const {
+        prefixCls,
+        localeMessage,
+        getMessage,
+        updateSelectedWallet,
+        updatePanelRoute,
+        panelRoute,
+      } = useContext(connectModalContext);
       return (
         <div>
           <ConnectModalContextProvider
@@ -22,6 +29,11 @@ describe('MainPanelHeader test', async () => {
               panelRouteBack: onPanelRouteBackCallTest,
               prefixCls,
               canBack: true,
+              localeMessage,
+              getMessage,
+              updateSelectedWallet,
+              panelRoute,
+              updatePanelRoute,
             }}
           >
             <MainPanelHeader title="title" onBack={() => Promise.resolve(true)} />

--- a/packages/web3/src/connect-modal/__tests__/MainPanelHeader.test.tsx
+++ b/packages/web3/src/connect-modal/__tests__/MainPanelHeader.test.tsx
@@ -1,0 +1,39 @@
+import { useContext } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { Grid } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+
+import MainPanelHeader from '../components/MainPanelHeader';
+import { connectModalContext, ConnectModalContextProvider } from '../context';
+
+describe('MainPanelHeader test', async () => {
+  const onPanelRouteBackCallTest = vi.fn();
+  it('When canBack is true, the panelRouteBack function is triggered.', async () => {
+    vi.spyOn(Grid, 'useBreakpoint').mockReturnValue({
+      md: true, // ≥ 768px, mock PC
+    });
+
+    const App = () => {
+      const { prefixCls } = useContext(connectModalContext);
+      return (
+        <div>
+          <ConnectModalContextProvider
+            value={{
+              panelRouteBack: onPanelRouteBackCallTest,
+              prefixCls,
+              canBack: true,
+            }}
+          >
+            <MainPanelHeader title="title" onBack={() => Promise.resolve(true)} />
+          </ConnectModalContextProvider>
+        </div>
+      );
+    };
+    const { baseElement } = render(<App />);
+    const btn = baseElement.querySelector('.ant-web3-connect-modal-main-panel-header-back');
+    fireEvent.click(btn!);
+    await vi.waitFor(() => {
+      expect(onPanelRouteBackCallTest).toBeCalled();
+    });
+  });
+});


### PR DESCRIPTION
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/b7924d74-207c-4116-8440-36c18da45a36)


![image](https://github.com/ant-design/ant-design-web3/assets/117748716/05f8e535-3002-48d7-a0ce-a35da9f13f12)

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/769d8d63-305c-44c7-a20c-bbf1906bd7b4)

最后两个关于test ci覆盖的pr补充上就100% coverage了
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/afb457ae-4356-423d-8b99-2645784eb046)
