### PR TITLE
refactor: displayIcon of the BrowserLink

### DIFF
--- a/.changeset/little-clocks-bathe.md
+++ b/.changeset/little-clocks-bathe.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+refactor: displayIcon of the BrowserLink

--- a/packages/web3/src/browser-link/index.tsx
+++ b/packages/web3/src/browser-link/index.tsx
@@ -40,7 +40,7 @@ export const BrowserLink: React.FC<BrowserLinkProps> = (props) => {
     ? React.cloneElement<any>(mergedIcon, {
         style: {
           ...props.iconStyle,
-          ...(React.isValidElement(mergedIcon) ? mergedIcon.props.style : {}),
+          ...mergedIcon.props.style,
         },
       })
     : mergedIcon;


### PR DESCRIPTION
这段代码是deadcode
如果`React.isValidElement`为false的时候直接返回`mergedIcon`了, 不需要在合并style的时候再做一次三元运算.
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/965b9264-2c9d-483e-bcfc-bb3078d29e5b)

清除这段代码还能提高一下覆盖率
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/595ebdc6-d66a-4a6c-bc5d-12d63b4da851)
