### PR TITLE
test: Increase ConnectButton's tooltip test coverage

### DIFF
--- a/packages/web3/src/connect-button/__tests__/tooltip.test.tsx
+++ b/packages/web3/src/connect-button/__tests__/tooltip.test.tsx
@@ -14,6 +14,34 @@ describe('ConnectButton', () => {
     resetMockClipboard();
   });
 
+  it('when tooltip is boolean, ant-tooltip not toBeNull', async () => {
+    const App = () => {
+      return (
+        <ConnectButton
+          account={{ address: '3ea2cfd153b8d8505097b81c87c11f5d05097c18' }}
+          tooltip={true}
+        />
+      );
+    };
+    const { baseElement, rerender } = render(<App />);
+    const btn = baseElement.querySelector('.ant-web3-address-text')!;
+    fireEvent.mouseEnter(btn);
+    rerender(<App />);
+    // When the tooltip's title is string, baseElement.outerHTML does not contain '.ant-tooltip'.
+    // mouseEnterDelay defaults is 0.1s and waitFakeTimer is required.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(baseElement.querySelector('.ant-tooltip')).not.toBeNull();
+  });
+  it('when mergedTitle does not exist, ant-tooltip toBeNull', () => {
+    const { baseElement } = render(
+      <ConnectButton
+        account={{ address: '3ea2cfd153b8d8505097b81c87c11f5d05097c18' }}
+        tooltip={{ open: true, copyable: true, title: undefined }}
+      />,
+    );
+    expect(baseElement.querySelector('.ant-tooltip')).toBeNull();
+  });
+
   it('display tooltip', () => {
     const { baseElement } = render(
       <ConnectButton

--- a/packages/web3/src/connect-button/index.md
+++ b/packages/web3/src/connect-button/index.md
@@ -55,7 +55,7 @@ The button to connect to the blockchain wallet. Usually, you need to use it with
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | account | Current connected account | `Account` | - | - |
-| tooltip | Show tooltip when mouse enter address | `boolean \|` [ConnectButtonTooltipProps](#connectbuttontooltipprops) | `true`, will display address by default | - |
+| tooltip | Show tooltip when mouse enter address | `boolean \|` [ConnectButtonTooltipProps](#connectbuttontooltipprops) | `false` | - |
 | actionsMenu | Config menu items | `boolean \|` [ActionsMenu](#actionsmenu) | - | - |
 | profileModal | Config profile modal | `boolean \|` [ProfileModal](#profilemodal) | - | - |
 | avatar | Config avatar, used to display user avatar in profile modal | [AvatarProps](https://ant.design/components/avatar-cn#api) | - | - |

--- a/packages/web3/src/connect-button/index.zh-CN.md
+++ b/packages/web3/src/connect-button/index.zh-CN.md
@@ -55,7 +55,7 @@ order: 1
 | 属性 | 描述 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | account | 当前连接账号 | `Account` | - | - |
-| tooltip | 鼠标移入地址时展示提示 | `boolean \|` [ConnectButtonTooltipProps](#connectbuttontooltipprops) | `true`，默认显示 address 信息 | - |
+| tooltip | 鼠标移入地址时展示提示 | `boolean \|` [ConnectButtonTooltipProps](#connectbuttontooltipprops) | `false` | - |
 | actionsMenu | 配置菜单项 | `boolean \|` [ActionsMenu](#actionsmenu) | - | - |
 | profileModal | 配置信息弹框 | `boolean \|` [ProfileModal](#profilemodal) | - | - |
 | avatar | 配置头像，用于在个人信息弹框中展示用户头像 | [AvatarProps](https://ant.design/components/avatar-cn#api) | - | - |


### PR DESCRIPTION
发现codecov 覆盖其实没有覆盖100%，我最近慢慢抽空把这个覆盖了。

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/64e44c3a-caf5-4af3-b812-e3f6fea37698)
