### PR TITLE
refactor: modify connector code

### DIFF
--- a/.changeset/eight-frogs-tan.md
+++ b/.changeset/eight-frogs-tan.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+refactor: modify connector code

--- a/packages/web3/src/connector/__tests__/basic.test.tsx
+++ b/packages/web3/src/connector/__tests__/basic.test.tsx
@@ -47,7 +47,7 @@ describe('Connector', () => {
     expect(() => render(<Connector>{null}</Connector>)).not.toThrow();
     expect(mockConsoleError.calls.length).toBe(1);
     expect(mockConsoleError.calls[0]).toContain(
-      '"children" property of the "Connector" is required',
+      '"children" property of the "Connector" is must be a React element',
     );
     console.error = originalConsoleError;
   });

--- a/packages/web3/src/connector/connector.tsx
+++ b/packages/web3/src/connector/connector.tsx
@@ -45,8 +45,8 @@ export const Connector: React.FC<ConnectorProps> = (props) => {
     }
   };
 
-  if (!children) {
-    console.error('"children" property of the "Connector" is required');
+  if (!React.isValidElement(children)) {
+    console.error('"children" property of the "Connector" is must be a React element');
     return null;
   }
 
@@ -74,7 +74,7 @@ export const Connector: React.FC<ConnectorProps> = (props) => {
           onChainSwitched?.(c);
         },
         loading,
-        ...(isValidElement(children) ? children.props : {}),
+        ...children.props,
       })}
 
       <ConnectModal


### PR DESCRIPTION
#529 之前这个pr中提到的错误是因为```React.cloneElement``` 导致的，并且下面这段代码也是执行不到的，没意义的，因为如果不是合法的时候已经页面报错了，所以可以再进一步优化一下，顺便还能提高一下覆盖率

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/e160e2cd-aaa8-462e-86d7-68a0ab0c65ca)

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/2d256b7c-c5b7-4b1d-a07f-dc7bcf9d5564)
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/093ba980-b5f7-40fb-8704-594635d9f7d4)

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/495a63a8-89b9-4db0-8bfe-fd381869e0c7)
