### PR TITLE
test: Increase ConnectButton & Connector test coverage

### DIFF
--- a/packages/web3/src/connect-button/__tests__/connect.test.tsx
+++ b/packages/web3/src/connect-button/__tests__/connect.test.tsx
@@ -7,6 +7,7 @@ import { ConnectButton, Web3ConfigProvider, type Account } from '../../../../web
 
 describe('ConnectButton connect', async () => {
   it('connect', async () => {
+    const onClickCallFn = vi.fn();
     const CustomConnector = () => {
       const { connect, account, disconnect } = useProvider();
 
@@ -21,6 +22,7 @@ describe('ConnectButton connect', async () => {
             }
             connect?.();
           }}
+          onClick={onClickCallFn}
           onDisconnectClick={() => {
             disconnect?.();
           }}
@@ -67,6 +69,7 @@ describe('ConnectButton connect', async () => {
 
     fireEvent.click(baseElement.querySelector('.custom-btn')!);
     await vi.waitFor(() => {
+      expect(onClickCallFn).toBeCalled();
       expect(baseElement.querySelector('.ant-web3-address-text')?.textContent).toBe(
         '0x1234...7890',
       );

--- a/packages/web3/src/connect-button/__tests__/index.test.tsx
+++ b/packages/web3/src/connect-button/__tests__/index.test.tsx
@@ -5,6 +5,17 @@ import { describe, expect, it } from 'vitest';
 import { ConnectButton } from '..';
 
 describe('ConnectButton', () => {
+  it(`when actionsMenu's extraItems is undefined, mount correctly`, async () => {
+    expect(() =>
+      render(
+        <ConnectButton
+          actionsMenu={{
+            extraItems: undefined,
+          }}
+        />,
+      ),
+    ).not.toThrow();
+  });
   it('mount correctly', () => {
     expect(() => render(<ConnectButton />)).not.toThrow();
   });

--- a/packages/web3/src/connector/__tests__/basic.test.tsx
+++ b/packages/web3/src/connector/__tests__/basic.test.tsx
@@ -11,6 +11,22 @@ import { Button } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('Connector', () => {
+  it('expect onCancelCallTest toBeCalled', async () => {
+    const onCancelCallTest = vi.fn();
+    const App = () => {
+      return (
+        <Connector modalProps={{ title: 'modal title', open: true, onCancel: onCancelCallTest }}>
+          <Button>children</Button>
+        </Connector>
+      );
+    };
+    const { baseElement } = render(<App />);
+    const btn = baseElement.querySelector('.ant-btn')!;
+    fireEvent.click(btn);
+    const closeBtn = baseElement.querySelector('.ant-modal-close')!;
+    fireEvent.click(closeBtn);
+    expect(onCancelCallTest).toBeCalled();
+  });
   it('render children', () => {
     const App = () => (
       <Connector>
@@ -53,6 +69,7 @@ describe('Connector', () => {
   it('connect', async () => {
     const onConnectCallTest = vi.fn();
     const onDisconnected = vi.fn();
+    const onDisconnect = vi.fn();
     const CustomButton: React.FC<React.PropsWithChildren<ConnectorTriggerProps>> = (props) => {
       const { account, onConnectClick, onDisconnectClick, children } = props;
       return (
@@ -94,6 +111,7 @@ describe('Connector', () => {
             setAccount(undefined);
           }}
           onDisconnected={onDisconnected}
+          onDisconnect={onDisconnect}
           onConnected={() => {
             onConnected();
           }}
@@ -127,6 +145,7 @@ describe('Connector', () => {
     fireEvent.click(baseElement.querySelector('.ant-btn')!);
     await vi.waitFor(() => {
       expect(onDisconnected).toBeCalled();
+      expect(onDisconnect).toBeCalled();
     });
     expect(baseElement.querySelector('.ant-btn')?.textContent).toBe('children');
   });


### PR DESCRIPTION
加上 #540 ，就完成codecov的100%覆盖了
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/bf85fd64-455d-4795-8de1-0681f03f812a)
