### PR TITLE
fix: connect-button warning

### DIFF
--- a/.changeset/shy-plants-deliver.md
+++ b/.changeset/shy-plants-deliver.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3-common': minor
+---
+
+fix:connect-button warning

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './request';
 export * from './format';
 export * from './test-utils';
 export * from './createGetBrowserLink';
+export * from './warning';


### PR DESCRIPTION
close #553

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/5605cbe6-4fac-4731-ac56-e1b1e882f4d5)
确实warning没打包出来，需要export一下打包才出来。
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/2006a138-bf7f-416c-8c04-6bc4646b540c)
