### PR TITLE
re-fix connect modal radius

### DIFF
--- a/.changeset/happy-penguins-taste.md
+++ b/.changeset/happy-penguins-taste.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix: connect modal radius

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -401,8 +401,6 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
           },
           [`${componentCls}-main-panel`]: {
             paddingInline: token.paddingLG,
-            background: token.colorBgContainer,
-            borderRadius: 16,
             [`${componentCls}-qr-code-box`]: {
               marginBlockStart: 24,
             },


### PR DESCRIPTION
重新修复了一下connect的圆角问题

原因是因为main-panel设置了背景色之后，覆盖在了modal 上面，导致圆角被覆盖了