### PR TITLE
Support okx x1 testnet

### DIFF
--- a/packages/assets/src/chains/ethereum.tsx
+++ b/packages/assets/src/chains/ethereum.tsx
@@ -6,6 +6,7 @@ import {
   EthereumCircleColorful,
   EthereumFilled,
   EtherscanCircleColorful,
+  OkxWalletColorful,
   OptimismCircleColorful,
   PolygonCircleColorful,
 } from '@ant-design/web3-icons';
@@ -85,4 +86,16 @@ export const Avalanche: Chain = {
     getBrowserLink: createGetBrowserLink('https://snowtrace.io'),
   },
   nativeCurrency: { name: 'Avalanche', symbol: 'AVAX', decimals: 18 },
+};
+
+// OKX X1: https://www.okx.com/cn/x1/docs/developer/build-on-x1/quickstart
+export const X1Testnet: Chain = {
+  id: ChainIds.X1Testnet,
+  name: 'X1 testnet',
+  icon: <OkxWalletColorful />,
+  browser: {
+    icon: <OkxWalletColorful />,
+    getBrowserLink: createGetBrowserLink('https://www.okx.com/explorer/x1-test'),
+  },
+  nativeCurrency: { name: 'OKB', symbol: 'OKB', decimals: 18 },
 };

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -11,6 +11,7 @@ export enum ChainIds {
   Optimism = 10,
   Goerli = 5,
   Avalanche = 43_114,
+  X1Testnet = 195,
 }
 
 export enum SolanaChainIds {

--- a/packages/web3/src/wagmi/demos/chains.tsx
+++ b/packages/web3/src/wagmi/demos/chains.tsx
@@ -1,14 +1,38 @@
 import { ConnectButton, Connector } from '@ant-design/web3';
-import { MetaMask, Polygon, WagmiWeb3ConfigProvider, WalletConnect } from '@ant-design/web3-wagmi';
+import {
+  MetaMask,
+  Polygon,
+  WagmiWeb3ConfigProvider,
+  WalletConnect,
+  X1Testnet,
+} from '@ant-design/web3-wagmi';
 import { createConfig, http } from 'wagmi';
-import { mainnet, polygon } from 'wagmi/chains';
+import { mainnet, polygon, type Chain } from 'wagmi/chains';
 import { injected, walletConnect } from 'wagmi/connectors';
 
+export const x1Testnet: Chain = {
+  id: X1Testnet.id,
+  name: X1Testnet.name,
+  nativeCurrency: { name: 'OKB', symbol: 'OKB', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://testrpc.x1.tech'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'X1TestnetScan',
+      url: 'https://www.okx.com/explorer/x1-test',
+    },
+  },
+};
+
 const config = createConfig({
-  chains: [mainnet, polygon],
+  chains: [mainnet, polygon, x1Testnet],
   transports: {
     [mainnet.id]: http(),
     [polygon.id]: http(),
+    [x1Testnet.id]: http(),
   },
   connectors: [
     injected({
@@ -25,7 +49,7 @@ const App: React.FC = () => {
   return (
     <WagmiWeb3ConfigProvider
       wallets={[MetaMask(), WalletConnect()]}
-      chains={[Polygon]}
+      chains={[Polygon, X1Testnet]}
       config={config}
     >
       <Connector>


### PR DESCRIPTION
<img width="312" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/17971291/a010e4fc-ae39-497f-b284-443e951300f5">

目前针对 `wagmi/chains` 未提供的链配置如何提供还没有统一的方案，而且和我们自己的链配置 Chain 信息有很大重叠。

Fix #600 