### PR TITLE
feat(web3): supports signMessage, add login example after connecting

### DIFF
--- a/.changeset/friendly-moose-suffer.md
+++ b/.changeset/friendly-moose-suffer.md
@@ -1,0 +1,6 @@
+---
+'@ant-design/web3-common': minor
+'@ant-design/web3-wagmi': minor
+---
+
+feat: add sign-message interface in web3-config-provider

--- a/.changeset/thirty-cows-provide.md
+++ b/.changeset/thirty-cows-provide.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+chore: add signin demo for wagmi users

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -75,6 +75,12 @@ export interface UniversalWeb3ProviderInterface {
   disconnect?: () => Promise<void>;
   switchChain?: (chain: Chain) => Promise<void>;
 
+  // sign utf-8/raw message or typed data(EIP-712)
+  signMessage?: (
+    // biome-ignore lint/suspicious/noExplicitAny: any means not limited
+    message: string | { raw: Uint8Array } | Record<PropertyKey, any>,
+  ) => Promise<{ signature: string }>;
+
   getNFTMetadata?: (params: { address: string; tokenId: bigint }) => Promise<NFTMetadata>;
 }
 

--- a/packages/wagmi/src/wagmi-provider/config-provider.tsx
+++ b/packages/wagmi/src/wagmi-provider/config-provider.tsx
@@ -7,6 +7,11 @@ import {
   type Locale,
   type Wallet,
 } from '@ant-design/web3-common';
+import {
+  signTypedData,
+  signMessage as wagmiSignMessage,
+  type SignTypedDataParameters,
+} from '@wagmi/core';
 import type { Chain as WagmiChain } from 'viem';
 import {
   useAccount,
@@ -229,6 +234,28 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
       getNFTMetadata={async ({ address: contractAddress, tokenId }) =>
         getNFTMetadata(config, contractAddress, tokenId, chain?.id)
       }
+      signMessage={async (message) => {
+        let signature: string;
+        if (typeof message === 'string') {
+          signature = await wagmiSignMessage(config, { message });
+        } else if (message?.raw && message.raw instanceof Uint8Array) {
+          signature = await wagmiSignMessage(config, {
+            account: account?.address as `0x${string}`,
+            message: { raw: message.raw },
+          });
+        } else {
+          // ERC712 spec the typed data must be an object and contains types and message
+          // See: https://eips.ethereum.org/EIPS/eip-712
+          // Here should do some validation for the typed data.
+          const typedData = message as SignTypedDataParameters;
+
+          if (!typedData?.types || !typedData?.message) {
+            throw new Error("The 'message' and 'types' is required for signTypedData");
+          }
+          signature = await signTypedData(config, typedData);
+        }
+        return { signature };
+      }}
     >
       {children}
     </Web3ConfigProvider>

--- a/packages/web3/src/wagmi/demos/signin.tsx
+++ b/packages/web3/src/wagmi/demos/signin.tsx
@@ -1,0 +1,60 @@
+import { ConnectButton, Connector, useProvider } from '@ant-design/web3';
+import { MetaMask, WagmiWeb3ConfigProvider } from '@ant-design/web3-wagmi';
+import { message } from 'antd';
+import { createConfig, http } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
+import { injected } from 'wagmi/connectors';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Mock backend services
+const services = {
+  GetMessage: async () => {
+    await sleep(500);
+    return `Sign this message to login to our app. Nonce: ${Date.now()}`; // Mock nonce
+  },
+  PostSignin: async (_signature?: string) => {
+    await sleep(500);
+    return !!_signature;
+  },
+};
+
+const Signin: React.FC = () => {
+  const { signMessage } = useProvider();
+
+  return (
+    <Connector
+      modalProps={{ mode: 'simple' }}
+      onConnected={async () => {
+        const signResult = await signMessage?.(await services.GetMessage());
+
+        const loginResult = await services.PostSignin(signResult?.signature);
+        if (loginResult) {
+          message.success('Login success');
+        } else {
+          message.error('Login failed');
+        }
+      }}
+    >
+      <ConnectButton />
+    </Connector>
+  );
+};
+
+export const App: React.FC = () => {
+  return (
+    <WagmiWeb3ConfigProvider
+      config={createConfig({
+        chains: [mainnet],
+        transports: { [mainnet.id]: http() },
+        connectors: [injected({ target: 'metaMask' })],
+      })}
+      wallets={[MetaMask()]}
+      eip6963={{ autoAddInjectedWallets: true }}
+    >
+      <Signin />
+    </WagmiWeb3ConfigProvider>
+  );
+};
+
+export default App;

--- a/packages/web3/src/wagmi/index.md
+++ b/packages/web3/src/wagmi/index.md
@@ -88,6 +88,12 @@ When the `showQrModal` configuration is not `false`, the built-in [web3modal](ht
 
 <code src="./demos/web3modal.tsx"></code>
 
+## Sign in
+
+After connecting the wallet, complete the login by signing the user information through `onConnected` callback.
+
+<code src="./demos/signin.tsx"></code>
+
 ## API
 
 ### WagmiWeb3ConfigProviderProps

--- a/packages/web3/src/wagmi/index.zh-CN.md
+++ b/packages/web3/src/wagmi/index.zh-CN.md
@@ -86,6 +86,12 @@ Ant Design Web3 内置了对 [TokenPocket](https://www.tokenpocket.pro/) 的支�
 
 <code src="./demos/web3modal.tsx"></code>
 
+## 登陆
+
+连接钱包后通过 `onConnected` 回调签名用户信息完成登陆。
+
+<code src="./demos/signin.tsx"></code>
+
 ## API
 
 ### WagmiWeb3ConfigProviderProps


### PR DESCRIPTION
几个变化：
* `signMessage` 作为一个比较常用的方法签名，添加到了 `UniversalWeb3ProviderInterface` 类型上，理论上其他链的 Provider 都应该实现这个方法（solana 可以看下 @gin-lsl ）
* 目前通过 `onConnected` 回调添加了连接钱包后登陆的流程示例，需要考虑下怎么默认集成到组件（或 web3-wagmi）中