### PR TITLE
ci: DingTalk Release Notification

### DIFF
--- a/.github/workflows/release-dingtalk.yml
+++ b/.github/workflows/release-dingtalk.yml
@@ -1,0 +1,27 @@
+name: DingTalk Release Notification
+
+on:
+  create
+
+permissions:
+  contents: read
+
+jobs:
+  release-helper:
+    permissions:
+      contents: write  # for actions-cool/release-helper to create releases
+    if: github.event.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send to Ant Design Web3 DingGroup
+        uses: actions-cool/release-helper@v2
+        with:
+          trigger: 'tag'
+          branch: 'main'
+          dingding-token: ${{ secrets.WEB3_DINGDING_BOT_TOKEN }}
+          msg-title: '{{v}} 发布日志'
+          msg-poster: 'https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*zx7LTI_ECSAAAAAAAAAAAABkARQnAQ'
+          msg-footer: '💬 前往 [**Ant Design Web3 Releases**]({{url}}) 查看更新日志  🐦 twitter: https://twitter.com/AntDesignWeb3'
+          prettier: true
+          prerelease-notice: true
+          prerelease-filter: '-, a, b, A, B'


### PR DESCRIPTION
## 测试效果

发送消息，并创建pre-release

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/3f94cd5e-cd97-4906-ba36-664289367802)

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/4f584053-fd00-4c83-8840-08b444741e3b)

## 配置
需要佬们配置一个bot，并在仓库设置 `WEB3_DINGDING_BOT_TOKEN`
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/a1d58e42-c5bd-4059-a9fb-e163748d73f7)

## 其他
目前这个勉强够用，如果后面有一些定制化任务，我可以做一个action专门用于该仓库定制的消息通知。


