### PR TITLE
fix: qr code scan tip text for universal protocol

### DIFF
--- a/.changeset/smooth-trees-stare.md
+++ b/.changeset/smooth-trees-stare.md
@@ -1,0 +1,6 @@
+---
+'@ant-design/web3-common': patch
+'@ant-design/web3': patch
+---
+
+fix: qr code scan tip text for universal protocol

--- a/packages/common/src/locale/en_US.ts
+++ b/packages/common/src/locale/en_US.ts
@@ -29,6 +29,7 @@ const localeValues: RequiredLocale = {
       'Select a wallet on the left to get started with a different wallet provider.',
     qrCodePanelTitleForDownload: 'Download {walletName}',
     qrCodePanelTitleForScan: 'Scan with {walletName}',
+    qrCodePanelTitleForUniversalProtocol: 'Scan with your wallet',
     qrCodePanelLinkForDownload: 'Click to go to the download page',
     qrCodePanelLinkForConnect: 'Click to connect directly',
     qrCodePanelDownloadTipForReady: 'Scan the QR code to download the wallet.',

--- a/packages/common/src/locale/zh_CN.ts
+++ b/packages/common/src/locale/zh_CN.ts
@@ -27,6 +27,7 @@ const localeValues: RequiredLocale = {
     getWalletPanelInfoDesc: '在左侧选择钱包，以开始使用不同的钱包提供商。',
     qrCodePanelTitleForDownload: '下载 {walletName}',
     qrCodePanelTitleForScan: '使用 {walletName} 扫描',
+    qrCodePanelTitleForUniversalProtocol: '使用你的钱包扫描',
     qrCodePanelLinkForDownload: '点击前往下载页面',
     qrCodePanelLinkForConnect: '点击直接连接',
     qrCodePanelDownloadTipForReady: '扫描二维码下载钱包',

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -217,6 +217,7 @@ export interface RequiredLocale {
     getWalletPanelInfoDesc: string;
     qrCodePanelTitleForDownload: string;
     qrCodePanelTitleForScan: string;
+    qrCodePanelTitleForUniversalProtocol: string;
     qrCodePanelLinkForDownload: string;
     qrCodePanelLinkForConnect: string;
     qrCodePanelDownloadTipForReady: string;

--- a/packages/web3/src/connect-modal/components/QrCode.tsx
+++ b/packages/web3/src/connect-modal/components/QrCode.tsx
@@ -48,7 +48,9 @@ const QrCode: React.FC<QrCodeProps> = (props) => {
         title={getMessage(
           download
             ? localeMessage.qrCodePanelTitleForDownload
-            : localeMessage.qrCodePanelTitleForScan,
+            : wallet.universalProtocol
+              ? localeMessage.qrCodePanelTitleForUniversalProtocol
+              : localeMessage.qrCodePanelTitleForScan,
           {
             walletName: wallet.name,
           },

--- a/packages/web3/src/connector/__tests__/quick-connect.test.tsx
+++ b/packages/web3/src/connector/__tests__/quick-connect.test.tsx
@@ -109,6 +109,12 @@ describe('Connector quick connect', () => {
       expect(baseElement.querySelector('.ant-btn-loading-icon')).toBeTruthy();
       expect(baseElement.querySelector('.ant-modal-body')).toBeTruthy();
       expect(baseElement.querySelector('.ant-web3-connect-modal-qr-code')).toBeTruthy();
+      expect(baseElement.querySelector('.ant-web3-connect-modal-get-wallet-tip')?.textContent).toBe(
+        "Don't know WalletConnect?",
+      );
+      expect(
+        baseElement.querySelector('.ant-web3-connect-modal-main-panel-header-title')?.textContent,
+      ).toBe('Scan with your wallet');
     });
   });
 


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 📝 Git Commit Message Convention

fix: qr code scan tip text for universal protocol

通用协议的二维码不是某一个特定钱包的二维码，文案要对应改一下。

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
