### PR TITLE
chore(card): use `styles.body` instead of `bodyStyle`

### DIFF
--- a/.changeset/funny-flies-hug.md
+++ b/.changeset/funny-flies-hug.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+chore(card): use `styles.body` instead of `bodyStyle`

--- a/.dumi/theme/builtins/HomePage/components/Theme/index.tsx
+++ b/.dumi/theme/builtins/HomePage/components/Theme/index.tsx
@@ -102,8 +102,10 @@ export const Theme: React.FC = () => {
       >
         <Card
           className={styles.card}
-          bodyStyle={{
-            padding: 0,
+          styles={{
+            body: {
+              padding: 0,
+            },
           }}
         >
           <ConnectModal.ModalPanel walletList={walletList} />

--- a/docs/guide/demos/custom-token.tsx
+++ b/docs/guide/demos/custom-token.tsx
@@ -54,9 +54,11 @@ const App: React.FC = () => {
     <ConfigProvider theme={customToken}>
       <Space>
         <Card
-          bodyStyle={{
-            padding: 0,
-            maxWidth: 737,
+          styles={{
+            body: {
+              padding: 0,
+              maxWidth: 737,
+            },
           }}
         >
           <ConnectModal.ModalPanel walletList={walletList} />

--- a/docs/guide/demos/theme.tsx
+++ b/docs/guide/demos/theme.tsx
@@ -67,9 +67,11 @@ const App: React.FC = () => {
         }}
       >
         <Card
-          bodyStyle={{
-            padding: 0,
-            maxWidth: 737,
+          styles={{
+            body: {
+              padding: 0,
+              maxWidth: 737,
+            },
           }}
         >
           <ConnectModal.ModalPanel walletList={walletList} />

--- a/packages/web3/src/connect-modal/demos/panel.tsx
+++ b/packages/web3/src/connect-modal/demos/panel.tsx
@@ -57,8 +57,10 @@ const App: React.FC = () => {
       style={{
         maxWidth: 797,
       }}
-      bodyStyle={{
-        padding: 0,
+      styles={{
+        body: {
+          padding: 0,
+        },
       }}
     >
       <ConnectModal.ModalPanel


### PR DESCRIPTION
替换移除的api

![, feialatienl Aoed -sussive eoent Liatenar sere1l-alocking touchatart cvet  Ceasiaer](https://github.com/ant-design/ant-design-web3/assets/117748716/d21ba322-cddf-4048-91ad-0f62903f179c)
