### PR TITLE
ci: Replacing release-helper's uses

### DIFF
--- a/.github/workflows/release-dingtalk.yml
+++ b/.github/workflows/release-dingtalk.yml
@@ -17,8 +17,6 @@ jobs:
       - name: Send to Ant Design Web3 DingGroup
         uses: thinkasany/release-helper@master
         with:
-          trigger: 'tag'
-          branch: 'main'
           dingding-token: ${{ secrets.WEB3_DINGDING_BOT_TOKEN }}
           msg-title: '{{v}} 发布日志'
           msg-poster: 'https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*zx7LTI_ECSAAAAAAAAAAAABkARQnAQ'

--- a/.github/workflows/release-dingtalk.yml
+++ b/.github/workflows/release-dingtalk.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send to Ant Design Web3 DingGroup
-        uses: actions-cool/release-helper@v2
+        uses: thinkasany/release-helper@master
         with:
           trigger: 'tag'
           branch: 'main'
@@ -23,6 +23,3 @@ jobs:
           msg-title: '{{v}} 发布日志'
           msg-poster: 'https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*zx7LTI_ECSAAAAAAAAAAAABkARQnAQ'
           msg-footer: '💬 前往 [**Ant Design Web3 Releases**]({{url}}) 查看更新日志  🐦 twitter: https://twitter.com/AntDesignWeb3'
-          prettier: true
-          prerelease-notice: true
-          prerelease-filter: '-, a, b, A, B'

--- a/.github/workflows/release-dingtalk.yml
+++ b/.github/workflows/release-dingtalk.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send to Ant Design Web3 DingGroup
-        uses: thinkasany/release-helper@master
+        uses: thinkasany/release-helper@main
         with:
           dingding-token: ${{ secrets.WEB3_DINGDING_BOT_TOKEN }}
           msg-title: '{{v}} 发布日志'


### PR DESCRIPTION
之前不会触发trigger可能是因为tag是老的，所以重新发布也没用，我多次测试了一下都能正常发布（也遇到了老的tag不触发，新的tag都是正常的）。

怀疑第一次skip也是因为同时触发了太多次的tag 所以导致了skip

但是由于项目的特殊性，的确tag不是很合适，会同时出现好几个tag，release-helper 不能很好的支持release，里面的代码过度依赖tag了，也没有对应监听release的属性，因此我fork下来做了改动。在后期维护上，我会使用@dev分支测试，@main做为稳定版不影响项目的正常使用 。

现在都是取release的参数，更适合本项目的自动化。
<img width="330" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/1c5abb93-0c5e-4ddb-995f-60479c459724">

具体代码逻辑几十行，就是替换了一下yml的配置和调用了钉钉的webhook，维护起来成本也不高，后续针对markdown格式也更好私人订制。

https://github.com/thinkasany/release-helper/blob/main/src/main.ts

<img width="468" alt="Pasted Graphic" src="https://github.com/ant-design/ant-design-web3/assets/117748716/3a3ef95c-ca07-4e00-97c1-d8cfe1a084f4">
