### PR TITLE
fix: move @tanstack/react-query to peerDependencies for fix react-query context error

### DIFF
--- a/.changeset/unlucky-knives-visit.md
+++ b/.changeset/unlucky-knives-visit.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3-wagmi': patch
+---
+
+fix: move @tanstack/react-query to peerDependencies for fix react-query context error

--- a/docs/course/dev-connect.md
+++ b/docs/course/dev-connect.md
@@ -16,7 +16,7 @@ In this part of the course, we will guide you to connect the DApp to the blockch
 First, similar to the [Quick Start](../guide/quick-start.md) documentation guide, we need to install some dependencies. In the previous course, we have installed `antd` and `@ant-design/web3`, so we only need to install `@ant-design/web3-wagmi` and `wagmi` next.
 
 ```shell
-npm i @ant-design/web3-wagmi wagmi @tanstack/react-query --save
+npm i @ant-design/web3-wagmi wagmi viem @tanstack/react-query --save
 ```
 
 `@ant-design/web3` is a UI component library, which connects to different blockchains through different [adapters](../guide/adapter.md). In this course, we mainly use [Ethereum](https://ethereum.org/) as an example. Correspondingly, we will also use the [adapter of Ethereum](../../packages/web3/src/wagmi/index.md) to implement the requirements of the course.

--- a/docs/course/dev-connect.md
+++ b/docs/course/dev-connect.md
@@ -16,7 +16,7 @@ In this part of the course, we will guide you to connect the DApp to the blockch
 First, similar to the [Quick Start](../guide/quick-start.md) documentation guide, we need to install some dependencies. In the previous course, we have installed `antd` and `@ant-design/web3`, so we only need to install `@ant-design/web3-wagmi` and `wagmi` next.
 
 ```shell
-npm i @ant-design/web3-wagmi wagmi --save
+npm i @ant-design/web3-wagmi wagmi @tanstack/react-query --save
 ```
 
 `@ant-design/web3` is a UI component library, which connects to different blockchains through different [adapters](../guide/adapter.md). In this course, we mainly use [Ethereum](https://ethereum.org/) as an example. Correspondingly, we will also use the [adapter of Ethereum](../../packages/web3/src/wagmi/index.md) to implement the requirements of the course.

--- a/docs/course/dev-connect.zh-CN.md
+++ b/docs/course/dev-connect.zh-CN.md
@@ -16,7 +16,7 @@ order: 2
 首先，同[快速开始](../guide/quick-start.zh-CN.md)中文档指引的类似，我们需要安装一些依赖。在上一篇课程中，我们已经安装了 `antd` 和 `@ant-design/web3`，所以我们接下来只需要安装 `@ant-design/web3-wagmi` 和 `wagmi`。
 
 ```shell
-npm i @ant-design/web3-wagmi wagmi @tanstack/react-query --save
+npm i @ant-design/web3-wagmi wagmi viem @tanstack/react-query --save
 ```
 
 `@ant-design/web3` 是一个 UI 组件库，它通过不同的[适配器](../guide/adapter.zh-CN.md)和不同的区块链连接。本课程中，我们主要基于的是[以太坊](https://ethereum.org/zh/)。对应的，我们也将使用[以太坊的适配器](../../packages/web3/src/wagmi/index.zh-CN.md)来实现课程的需求。

--- a/docs/course/dev-connect.zh-CN.md
+++ b/docs/course/dev-connect.zh-CN.md
@@ -16,7 +16,7 @@ order: 2
 首先，同[快速开始](../guide/quick-start.zh-CN.md)中文档指引的类似，我们需要安装一些依赖。在上一篇课程中，我们已经安装了 `antd` 和 `@ant-design/web3`，所以我们接下来只需要安装 `@ant-design/web3-wagmi` 和 `wagmi`。
 
 ```shell
-npm i @ant-design/web3-wagmi wagmi --save
+npm i @ant-design/web3-wagmi wagmi @tanstack/react-query --save
 ```
 
 `@ant-design/web3` 是一个 UI 组件库，它通过不同的[适配器](../guide/adapter.zh-CN.md)和不同的区块链连接。本课程中，我们主要基于的是[以太坊](https://ethereum.org/zh/)。对应的，我们也将使用[以太坊的适配器](../../packages/web3/src/wagmi/index.zh-CN.md)来实现课程的需求。

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -13,7 +13,7 @@ You can install the relevant dependencies under the root directory of the projec
 
 <br />
 
-<NormalInstallDependencies packageNames="antd @ant-design/web3 @ant-design/web3-wagmi wagmi @tanstack/react-query" save="true"></NormalInstallDependencies>
+<NormalInstallDependencies packageNames="antd @ant-design/web3 @ant-design/web3-wagmi wagmi viem @tanstack/react-query" save="true"></NormalInstallDependencies>
 
 <br />
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -13,7 +13,7 @@ You can install the relevant dependencies under the root directory of the projec
 
 <br />
 
-<NormalInstallDependencies packageNames="antd @ant-design/web3 @ant-design/web3-wagmi wagmi" save="true"></NormalInstallDependencies>
+<NormalInstallDependencies packageNames="antd @ant-design/web3 @ant-design/web3-wagmi wagmi @tanstack/react-query" save="true"></NormalInstallDependencies>
 
 <br />
 

--- a/docs/guide/quick-start.zh-CN.md
+++ b/docs/guide/quick-start.zh-CN.md
@@ -13,7 +13,7 @@ group: 基础
 
 <br />
 
-<NormalInstallDependencies packageNames="antd @ant-design/web3 @ant-design/web3-wagmi wagmi" save="true"></NormalInstallDependencies>
+<NormalInstallDependencies packageNames="antd @ant-design/web3 @ant-design/web3-wagmi wagmi @tanstack/react-query" save="true"></NormalInstallDependencies>
 
 <br />
 

--- a/docs/guide/quick-start.zh-CN.md
+++ b/docs/guide/quick-start.zh-CN.md
@@ -13,7 +13,7 @@ group: 基础
 
 <br />
 
-<NormalInstallDependencies packageNames="antd @ant-design/web3 @ant-design/web3-wagmi wagmi @tanstack/react-query" save="true"></NormalInstallDependencies>
+<NormalInstallDependencies packageNames="antd @ant-design/web3 @ant-design/web3-wagmi wagmi viem @tanstack/react-query" save="true"></NormalInstallDependencies>
 
 <br />
 

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -44,8 +44,7 @@
     "@ant-design/web3-common": "workspace:*",
     "debug": "^4.3.4",
     "@wagmi/core": "^2.6.5",
-    "viem": "2.0.0",
-    "@tanstack/react-query": "^5.28.4"
+    "viem": "2.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",
@@ -54,7 +53,8 @@
     "wagmi": "^2.5.7"
   },
   "peerDependencies": {
-    "wagmi": "^2.5.7"
+    "wagmi": "^2.5.7",
+    "@tanstack/react-query": "^5.28.4"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -50,11 +50,13 @@
     "father": "^4.3.8",
     "typescript": "^5.4.2",
     "wagmi": "^2.5.7",
-    "@tanstack/react-query": "^5.28.4"
+    "@tanstack/react-query": "^5.28.4",
+    "viem": "^2.0.0"
   },
   "peerDependencies": {
     "wagmi": "^2.5.7",
-    "@tanstack/react-query": "^5.28.4"
+    "@tanstack/react-query": "^5.28.4",
+    "viem": "^2.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -43,14 +43,14 @@
     "@ant-design/web3-assets": "workspace:*",
     "@ant-design/web3-common": "workspace:*",
     "debug": "^4.3.4",
-    "@wagmi/core": "^2.6.5",
-    "viem": "2.0.0"
+    "@wagmi/core": "^2.6.5"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12",
     "father": "^4.3.8",
     "typescript": "^5.4.2",
-    "wagmi": "^2.5.7"
+    "wagmi": "^2.5.7",
+    "@tanstack/react-query": "^5.28.4"
   },
   "peerDependencies": {
     "wagmi": "^2.5.7",

--- a/packages/wagmi/src/wagmi-provider/config-provider.tsx
+++ b/packages/wagmi/src/wagmi-provider/config-provider.tsx
@@ -7,7 +7,7 @@ import {
   type Locale,
   type Wallet,
 } from '@ant-design/web3-common';
-import type { Config } from 'wagmi';
+import type { Chain as WagmiChain } from 'viem';
 import {
   useAccount,
   useBalance,
@@ -31,7 +31,7 @@ export interface AntDesignWeb3ConfigProviderProps {
   ens?: boolean;
   balance?: boolean;
   eip6963?: EIP6963Config;
-  readonly availableChains: Config['chains'];
+  readonly availableChains: readonly WagmiChain[];
   readonly availableConnectors: readonly WagmiConnector[];
 }
 

--- a/packages/wagmi/src/wagmi-provider/config-provider.tsx
+++ b/packages/wagmi/src/wagmi-provider/config-provider.tsx
@@ -7,7 +7,7 @@ import {
   type Locale,
   type Wallet,
 } from '@ant-design/web3-common';
-import type { Chain as WagmiChain } from 'viem';
+import type { Config } from 'wagmi';
 import {
   useAccount,
   useBalance,
@@ -31,7 +31,7 @@ export interface AntDesignWeb3ConfigProviderProps {
   ens?: boolean;
   balance?: boolean;
   eip6963?: EIP6963Config;
-  readonly availableChains: readonly WagmiChain[];
+  readonly availableChains: Config['chains'];
   readonly availableConnectors: readonly WagmiConnector[];
 }
 

--- a/packages/wagmi/src/wallets/__tests__/im-token.test.tsx
+++ b/packages/wagmi/src/wallets/__tests__/im-token.test.tsx
@@ -1,7 +1,7 @@
 import { ImToken } from '@ant-design/web3-wagmi';
-import { mainnet } from 'viem/chains';
 import { describe, expect, it } from 'vitest';
 import { createConfig, http } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
 import { walletConnect } from 'wagmi/connectors';
 
 describe('ImToken', () => {

--- a/packages/wagmi/src/wallets/__tests__/okx-wallet.test.tsx
+++ b/packages/wagmi/src/wallets/__tests__/okx-wallet.test.tsx
@@ -1,7 +1,7 @@
 import { OkxWallet } from '@ant-design/web3-wagmi';
-import { mainnet } from 'viem/chains';
 import { describe, expect, it } from 'vitest';
 import { createConfig, http } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
 import { injected, walletConnect } from 'wagmi/connectors';
 
 describe('OkxWallet', () => {

--- a/packages/wagmi/src/wallets/__tests__/token-pocket.test.tsx
+++ b/packages/wagmi/src/wallets/__tests__/token-pocket.test.tsx
@@ -1,7 +1,7 @@
 import { TokenPocket } from '@ant-design/web3-wagmi';
-import { mainnet } from 'viem/chains';
 import { describe, expect, it } from 'vitest';
 import { createConfig, http } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
 import { injected, walletConnect } from 'wagmi/connectors';
 
 describe('TokenPocket', () => {

--- a/packages/web3/src/wagmi/demos/recommend.tsx
+++ b/packages/web3/src/wagmi/demos/recommend.tsx
@@ -6,9 +6,12 @@ import {
   WagmiWeb3ConfigProvider,
   WalletConnect,
 } from '@ant-design/web3-wagmi';
+import { QueryClient } from '@tanstack/react-query';
 import { createConfig, http } from 'wagmi';
 import { mainnet } from 'wagmi/chains';
 import { walletConnect } from 'wagmi/connectors';
+
+const queryClient = new QueryClient();
 
 const config = createConfig({
   chains: [mainnet],
@@ -39,10 +42,11 @@ const App: React.FC = () => {
         OkxWallet(),
       ]}
       config={config}
+      queryClient={queryClient}
     >
       <Connector
         modalProps={{
-          group: false,
+          mode: 'simple',
         }}
       >
         <ConnectButton quickConnect />

--- a/packages/web3/src/wagmi/index.md
+++ b/packages/web3/src/wagmi/index.md
@@ -23,12 +23,13 @@ We support rich configurations of wallets, protocols, and interaction methods. F
 
 The recommended configuration mainly includes:
 
-- Use the EIP6963 protocol to automatically add detected plugin wallets.
+- Use the EIP6963 protocol and automatically add detected plugin wallets.
 - Support displaying ENS.
 - By default, add MetaMask and TokenPocket, Okx wallets, and provide download guides when users have not installed wallets.
 - By default, add WalletConnect, which supports users to connect various wallets through mobile phone scanning.
 - Configure `quickConnect` to provide quick connection entry to simplify user operations.
-- Remove wallet grouping to simplify the ui.
+- Use the `simple` mode to simplify the interface.
+- Manually configure `queryClient` for easy subsequent customization of related configurations.
 
 ## Basic Usage
 

--- a/packages/web3/src/wagmi/index.zh-CN.md
+++ b/packages/web3/src/wagmi/index.zh-CN.md
@@ -22,12 +22,13 @@ Ant Design Web3 官方提供了 `@ant-design/web3-wagmi` 来适配以太坊，�
 
 该推荐配置主要包括：
 
-- 使用 EIP6963 协议，自动添加检测到的插件钱包。
+- 使用 EIP6963 协议，并自动添加检测到的插件钱包。
 - 支持显示 ENS。
 - 默认添加 MetaMask 和 TokenPocket、Okx 钱包，在用户未安装钱包情况下提供下载引导。
 - 默认添加 WalletConnect，支持用户通过手机扫码连接各类钱包。
 - 配置 `quickConnect`，提供快速连接入口，简化用户操作。
-- 去掉钱包分组，简化界面。
+- 使用 `simple` 模式，简化界面。
+- 手动配置 `queryClient`，方便后续自定义相关配置。
 
 ## 基本使用
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       typescript:
         specifier: ^5.4.2
         version: 5.4.2
+      viem:
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@5.4.2)
       wagmi:
         specifier: ^2.5.7
         version: 2.5.7(@tanstack/react-query@5.28.4)(@types/react@18.2.65)(react-dom@18.2.0)(react-native@0.73.2)(react@18.2.0)(typescript@5.4.2)(viem@2.0.0)
@@ -8649,7 +8652,7 @@ packages:
     peerDependencies:
       '@solana/web3.js': ^1.77.3
     dependencies:
-      '@noble/curves': 1.2.0
+      '@noble/curves': 1.3.0
       '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.89.1)
       '@solana/wallet-standard-features': 1.2.0
       '@solana/wallet-standard-util': 1.1.1
@@ -8662,7 +8665,7 @@ packages:
     peerDependencies:
       '@solana/web3.js': ^1.77.3
     dependencies:
-      '@noble/curves': 1.2.0
+      '@noble/curves': 1.3.0
       '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.91.0)
       '@solana/wallet-standard-features': 1.2.0
       '@solana/wallet-standard-util': 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,19 +298,16 @@ importers:
       '@ant-design/web3-common':
         specifier: workspace:*
         version: link:../common
-      '@tanstack/react-query':
-        specifier: ^5.28.4
-        version: 5.28.4(react@18.2.0)
       '@wagmi/core':
         specifier: ^2.6.5
         version: 2.6.5(@types/react@18.2.65)(react@18.2.0)(typescript@5.4.2)(viem@2.0.0)
       debug:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@5.5.0)
-      viem:
-        specifier: 2.0.0
-        version: 2.0.0(typescript@5.4.2)
     devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.28.4
+        version: 5.28.4(react@18.2.0)
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -9594,6 +9591,7 @@ packages:
 
   /@tanstack/query-core@5.28.4:
     resolution: {integrity: sha512-uQZqOFqLWUvXNIQZ63XdKzg22NtHzgCBUfDmjDHi3BoF+nUYeBNvMi/xFPtFrMhqRzG2Ir4mYaGsWZzmiEjXpA==}
+    dev: true
 
   /@tanstack/react-query@5.28.4(react@18.2.0):
     resolution: {integrity: sha512-BErcoB/QQG6YwLSUKnaGxF+lSc270RH2w3kMBpG0i4YzDCsFs2pdxPX1WVknQvFk9bNgukMb158hc2Zb4SdwSA==}
@@ -9602,6 +9600,7 @@ packages:
     dependencies:
       '@tanstack/query-core': 5.28.4
       react: 18.2.0
+    dev: true
 
   /@testing-library/dom@9.3.3:
     resolution: {integrity: sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==}


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 📝 Git Commit Message Convention

@tanstack/react-query 和 wagmi 一样应该是 peerDependencies，wagmi 中 peerDependencies 依赖了 @tanstack/react-query，wagmi 是 peerDependencies，@tanstack/react-query 应该也是 peerDependencies。不然构建工具打包的时候可能会重复构建多次 @tanstack/react-query，导致 context 不对。

issue 中出现的问题就是因为虽然在 `@ant-design/web3-wagmi` 中我们初始化并提供了 queryClient，但是在 wagmi 中使用的 react-query context 和 `@ant-design/web3-wagmi` 中的并不是同一个，所以会报没有初始化 queryClient。


## 🔗 Related issue link

close #501 
