### PR TITLE
 fix: add default alt attribute to img

### DIFF
--- a/packages/web3/src/connect-modal/components/WalletCard.tsx
+++ b/packages/web3/src/connect-modal/components/WalletCard.tsx
@@ -57,7 +57,10 @@ const WalletCard: React.FC = () => {
             link={selectedExtension.link}
             icon={
               typeof selectedExtension.browserIcon === 'string' ? (
-                <img src={selectedExtension.browserIcon} />
+                <img
+                  alt='selected extension browser icon'
+                  src={selectedExtension.browserIcon}
+                />
               ) : (
                 selectedExtension.browserIcon
               )
@@ -73,7 +76,10 @@ const WalletCard: React.FC = () => {
           <CardItem
             icon={
               typeof selectedWallet.icon === 'string' ? (
-                <img src={selectedWallet.icon} />
+                <img
+                  alt='selected wallet icon'
+                  src={selectedWallet.icon}
+                />
               ) : (
                 selectedWallet.icon
               )


### PR DESCRIPTION
Add default alt attribute to img

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 📝 Git Commit Message Convention

> This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).

## 🔗 Related issue link
