### PR TITLE
fix: Official Website Document UI anomaly

### DIFF
--- a/.dumi/theme/builtins/ThemeEditorPage/index.tsx
+++ b/.dumi/theme/builtins/ThemeEditorPage/index.tsx
@@ -1,21 +1,12 @@
 import React from 'react';
 import { ConfigProvider, message } from 'antd';
-import {
-  defaultAntdComponents,
-  parsePlainConfig,
-  parseThemeConfig,
-  Previewer,
-} from 'antd-token-previewer-web3';
+import { useTheme } from 'antd-style';
+import { parsePlainConfig, parseThemeConfig, Previewer } from 'antd-token-previewer-web3';
+import antdEnUS from 'antd/locale/en_US';
+import antdZhCN from 'antd/locale/zh_CN';
 import { useLocale } from 'dumi';
 
 import { components, demos } from './demos';
-
-import 'antd/es/style/reset.css';
-
-import { useTheme } from 'antd-style';
-import antdEnUS from 'antd/locale/en_US';
-import antdZhCN from 'antd/locale/zh_CN';
-
 import styles from './index.module.less';
 
 const ANT_DESIGN_WEB3_CUSTOM_THEME = 'ant-design-web3-custom-theme';


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## background and solution

是 import 'antd/es/style/reset.css'; 引入了 h1 {margin-bottom: 0.5em; } 从而导致污染全局样式的话。
<img width="1981" alt="Pasted Graphic 2" src="https://github.com/ant-design/ant-design-web3/assets/117748716/1d63fb65-77f4-4d07-9117-22c4825e03af">


对比两个pr的preivew，在677的时候都是好的，最后排查到`import 'antd/es/style/reset.css` 的影响，试了一下打包后的dist用express.static去加载看了是好的，一会观察一下preivew。
<img width="550" alt="chore support theme-editor（#664） m" src="https://github.com/ant-design/ant-design-web3/assets/117748716/06dc3829-8c30-46b2-977c-540f2a28752f">

https://preview-664-ant-design-web3.surge.sh/components/icons


https://preview-677-ant-design-web3.surge.sh/course/introduction

## 🔗 Related issue link
close #700
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
