### PR TITLE
ci: add PR Labeled

### DIFF
--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -1,0 +1,27 @@
+name: PR Labeled
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  issue-labeled:
+    permissions:
+      issues: write  # for actions-cool/issues-helper to update issues
+      pull-requests: write  # for actions-cool/issues-helper to update PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Need Changelog
+        if: github.event.label.name == 'Need Changelog'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "create-comment"
+          token: ${{ secrets.GH_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            You can run the pnpm changeset command locally to generate a changelog. Please refer to the operation precautions. https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
+
+            可以在本地运行 pnpm changeset 命令生成 changelog, 操作注意事项参考：https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-cool/issues-helper@v3
         with:
           actions: "create-comment"
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             You can run the pnpm changeset command locally to generate a changelog. Please refer to the operation precautions. https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution
针对pr的自动评论，有时候用户不熟悉我们的changelog规范，通过打label来自动回复可以节省我们重复整理并发送教程的步骤, 后续可以逐步补充label以及对应的教程。
<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
