### PR TITLE
chore(ci): update mentioned

### DIFF
--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -22,6 +22,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            @${{ github.actor }} You can run the `pnpm changeset` command locally to generate a changelog. Please refer to the operation precautions. https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
+            @${{ github.event.pull_request.user.login }} You can run the `pnpm changeset` command locally to generate a changelog. Please refer to the operation precautions. https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
 
-            @${{ github.actor }} 可以在本地运行 `pnpm changeset` 命令生成 changelog, 操作注意事项参考：https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
+            @${{ github.event.pull_request.user.login }} 可以在本地运行 `pnpm changeset` 命令生成 changelog, 操作注意事项参考：https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -22,6 +22,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            @${{ github.event.pull_request.user.login }} You can run the ```pnpm changese``` command locally to generate a changelog. Please refer to the operation precautions. https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
+            @${{ github.event.pull_request.user.login }} You can run the ```pnpm changeset``` command locally to generate a changelog. Please refer to the operation precautions. https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
 
             @${{ github.event.pull_request.user.login }} 可以在本地运行 ```pnpm changese``` 命令生成 changelog, 操作注意事项参考：https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -22,6 +22,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            @${{ github.event.pull_request.user.login }} You can run the `pnpm changeset` command locally to generate a changelog. Please refer to the operation precautions. https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
+            @${{ github.event.pull_request.user.login }} You can run the ```pnpm changese``` command locally to generate a changelog. Please refer to the operation precautions. https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
 
-            @${{ github.event.pull_request.user.login }} 可以在本地运行 `pnpm changeset` 命令生成 changelog, 操作注意事项参考：https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
+            @${{ github.event.pull_request.user.login }} 可以在本地运行 ```pnpm changese``` 命令生成 changelog, 操作注意事项参考：https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -24,4 +24,4 @@ jobs:
           body: |
             @${{ github.event.pull_request.user.login }} You can run the ```pnpm changeset``` command locally to generate a changelog. Please refer to the operation precautions. https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
 
-            @${{ github.event.pull_request.user.login }} 可以在本地运行 ```pnpm changese``` 命令生成 changelog, 操作注意事项参考：https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md
+            @${{ github.event.pull_request.user.login }} 可以在本地运行 ```pnpm changeset``` 命令生成 changelog, 操作注意事项参考：https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -1,7 +1,7 @@
 name: PR Labeled
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 permissions:


### PR DESCRIPTION
1. `github.actor` 是触发者，之前那个ci可以是因为是监听pr事件的，现在这边监听的是label，会艾特到打label的人有点错误。

2. trigger 也得修改，否则对fork的分支无法生效
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/4e5bb110-3894-4650-8f1b-f920d2bcd628)
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/8f123545-8b40-48b1-87d3-30d353d2a45d)
