### PR TITLE
chore(BabelPlugins): overrides configuration for svgo

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -301,5 +301,26 @@ export default defineConfig({
       suffix: '-cn',
     },
   ],
-  extraBabelPlugins: ['inline-react-svg', 'react-inline-svg-unique-id'],
+  extraBabelPlugins: [
+    [
+      'inline-react-svg',
+      {
+        svgo: {
+          plugins: [
+            {
+              name: 'preset-default',
+              params: {
+                overrides: {
+                  removeViewBox: false,
+                },
+              },
+            },
+            'removeDimensions',
+            'convertStyleToAttrs',
+          ],
+        },
+      },
+    ],
+    'react-inline-svg-unique-id',
+  ],
 });

--- a/.fatherrc.base.ts
+++ b/.fatherrc.base.ts
@@ -10,5 +10,26 @@ export default defineConfig({
     output: 'dist/esm',
     transformer: 'babel',
   },
-  extraBabelPlugins: ['inline-react-svg', 'react-inline-svg-unique-id'],
+  extraBabelPlugins: [
+    [
+      'inline-react-svg',
+      {
+        svgo: {
+          plugins: [
+            {
+              name: 'preset-default',
+              params: {
+                overrides: {
+                  removeViewBox: false,
+                },
+              },
+            },
+            'removeDimensions',
+            'convertStyleToAttrs',
+          ],
+        },
+      },
+    ],
+    'react-inline-svg-unique-id',
+  ],
 });


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution
1.  fill 写到了 style 里面，导致引用的时候颜色丢失
2. svgo 会移除 viewBox 的问题

🫡 @LCJove 
<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
3. Describe the problem and the scenario.
-->

## 🔗 Related issue link
#738 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
