### PR TITLE
feat: support icons:generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "clean:test": "rimraf --glob ./coverage ./packages/*/coverage ./examples/*/coverage",
     "husky:prepare": "husky install",
     "husky:pre-commit": "lint-staged",
-    "biome:format": "biome format --write ."
+    "biome:format": "biome format --write .",
+    "icons:generate": "NODE_OPTIONS='--experimental-specifier-resolution=node' node --loader ts-node/esm ./packages/icons/scripts/generate.ts"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
@@ -89,6 +90,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",
+    "ts-node": "^10.9.2",
     "typescript": "^5.4.2",
     "viem": "^2.0.0",
     "vite-plugin-svgr": "^4.2.0",

--- a/packages/icons/scripts/generate.ts
+++ b/packages/icons/scripts/generate.ts
@@ -17,7 +17,21 @@ interface IconDefinitionWithIdentifier extends IconDefinition {
   svgBase64: string | null;
 }
 
+const IdentifierMap: { [key: string]: string } = {
+  ImTokenCircleColorful: 'imtoken-circle-colorful',
+  ImTokenColorful: 'imtoken-colorful',
+  MetaMaskColorful: 'metamask-colorful',
+  OneInchColorful: 'oneinch-colorful',
+  PancakeSwapColorful: 'pancakeswap-colorful',
+  SushiSwapColorful: 'sushiswap-colorful',
+  TokenPocketColorful: 'tokenpocket-colorful',
+  TwoKeyCircleColorful: 'twokey-circle-colorful',
+};
+
 function camelToKebab(camelCaseString: string) {
+  if (Object.keys(IdentifierMap).some((key) => key === camelCaseString)) {
+    return IdentifierMap[camelCaseString];
+  }
   return camelCaseString
     .replace(/([a-z\d])([A-Z][a-z\d])|([A-Z]+(?![a-z\d]))/g, '$1$3-$2')
     .toLowerCase();
@@ -54,6 +68,8 @@ function walk<T>(fn: (iconDef: IconDefinitionWithIdentifier) => Promise<T>) {
         try {
           svgBase64 = svg2base64(realSvgPath);
         } catch (e) {}
+      } else {
+        console.log(svgIdentifier);
       }
       return fn({ svgIdentifier, svgBase64, svgPathToKebab, ...iconDef });
     }),

--- a/packages/icons/scripts/generate.ts
+++ b/packages/icons/scripts/generate.ts
@@ -19,7 +19,7 @@ interface IconDefinitionWithIdentifier extends IconDefinition {
 
 function camelToKebab(camelCaseString: string) {
   return camelCaseString
-    .replace(/([a-z\d])([A-Z][a-z])|([A-Z]+(?![a-z]))/g, '$1$3-$2')
+    .replace(/([a-z\d])([A-Z][a-z\d])|([A-Z]+(?![a-z\d]))/g, '$1$3-$2')
     .toLowerCase();
 }
 

--- a/packages/icons/scripts/generate.ts
+++ b/packages/icons/scripts/generate.ts
@@ -1,0 +1,133 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+import * as allIconDefs from '@ant-design/web3-icons';
+import pkg from 'lodash';
+
+const __dirname = new URL(import.meta.url).pathname;
+const { template } = pkg;
+
+const writeFile = promisify(fs.writeFile);
+
+interface IconDefinition {
+  [key: string]: any;
+}
+interface IconDefinitionWithIdentifier extends IconDefinition {
+  svgIdentifier: string;
+  svgBase64: string | null;
+}
+
+function camelToKebab(camelCaseString: string) {
+  return camelCaseString
+    .replace(/([a-z\d])([A-Z][a-z])|([A-Z]+(?![a-z]))/g, '$1$3-$2')
+    .toLowerCase();
+}
+
+function detectRealPath(_path: string) {
+  try {
+    return fs.existsSync(_path) ? _path : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function svg2base64(svgPath: string, size = 50) {
+  const svg = fs.readFileSync(svgPath, 'utf-8');
+  const svgWithStyle = svg.replace(/<svg/, `<svg width="${size}" height="${size}" fill="#cacaca"`);
+
+  const base64 = Buffer.from(svgWithStyle).toString('base64');
+  return `data:image/svg+xml;base64,${base64}`;
+}
+
+function walk<T>(fn: (iconDef: IconDefinitionWithIdentifier) => Promise<T>) {
+  return Promise.all(
+    Object.keys(allIconDefs).map((svgIdentifier) => {
+      const iconDef = (allIconDefs as { [id: string]: IconDefinition })[svgIdentifier];
+      const svgPathToKebab = camelToKebab(svgIdentifier);
+      const realSvgPath = detectRealPath(
+        path.resolve(__dirname, `../../src/svgs/${svgPathToKebab}.svg`),
+      );
+
+      let svgBase64: string | null = null;
+
+      if (realSvgPath) {
+        try {
+          svgBase64 = svg2base64(realSvgPath);
+        } catch (e) {}
+      }
+      return fn({ svgIdentifier, svgBase64, svgPathToKebab, ...iconDef });
+    }),
+  );
+}
+
+async function generateIcons() {
+  const iconsDir = path.join(__dirname, '../../src/svgs');
+
+  try {
+    await promisify(fs.access)(iconsDir);
+  } catch (err) {
+    await promisify(fs.mkdir)(iconsDir);
+  }
+
+  const render = template(
+    `
+// GENERATE BY ./scripts/generate.ts
+// DON NOT EDIT IT MANUALLY
+import * as React from 'react';
+import AntdIcon from '@ant-design/icons';
+import { type IconBaseProps } from '@ant-design/icons/lib/components/Icon';
+import { ConfigProvider } from 'antd';
+import classnames from 'classnames';
+
+import SVGComponent from '../svgs/<%= svgPathToKebab %>.svg';
+
+<% if (svgBase64) { %> /**![<%= svgIdentifier %>](<%= svgBase64 %>) */ <% } %>
+export const <%= svgIdentifier %> = React.forwardRef<HTMLSpanElement, IconBaseProps>((props, ref) => {
+  const { getPrefixCls } = React.useContext(ConfigProvider.ConfigContext);
+  const prefixCls = getPrefixCls('web3-icon-<%= svgPathToKebab %>');
+
+  return (
+    <AntdIcon
+      {...props}
+      className={classnames(prefixCls, props.className)}
+      ref={ref}
+      component={SVGComponent}
+    />
+  );
+});
+
+<%= svgIdentifier %>.displayName = '<%= svgIdentifier %>';
+
+`.trim(),
+  );
+
+  await walk(async (item) => {
+    // generate icon file
+    const svgPathToKebab = camelToKebab(item.svgIdentifier);
+
+    try {
+      await writeFile(
+        path.resolve(__dirname, `../../src/components/${svgPathToKebab}.tsx`),
+        render(item),
+      );
+    } catch (error) {}
+  });
+
+  // generate icon index
+  const entryText = Object.keys(allIconDefs)
+    .sort()
+    .map((svgIdentifier) => `export * from './components/${camelToKebab(svgIdentifier)}';`)
+    .join('\n');
+
+  await promisify(fs.appendFile)(
+    path.resolve(__dirname, '../../src/index.ts'),
+    `
+  // GENERATE BY ./scripts/generate.ts
+  // DON NOT EDIT IT MANUALLY
+
+  ${entryText}
+      `.trim(),
+  );
+}
+
+generateIcons();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.10.5)(typescript@5.4.2)
       typescript:
         specifier: ^5.4.2
         version: 5.4.2
@@ -398,7 +401,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.25
 
   /@ant-design/colors@6.0.0:
     resolution: {integrity: sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==}
@@ -3552,6 +3555,13 @@ packages:
       - supports-color
     dev: true
 
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
   /@csstools/css-parser-algorithms@2.4.0(@csstools/css-tokenizer@2.2.2):
     resolution: {integrity: sha512-/PPLr2g5PAUCKAPEbfyk6/baZA+WJHQtUhPkoCQMpyRE8I0lXrG1QFRN8e5s3ZYxM8d/g5BZc6lH3s8Op7/VEg==}
     engines: {node: ^14 || ^16 || >=18}
@@ -5587,7 +5597,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.6
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -5700,7 +5710,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.25
 
   /@jridgewell/gen-mapping@0.3.5:
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
@@ -5726,7 +5736,7 @@ packages:
     resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.25
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
@@ -5736,12 +5746,20 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@jridgewell/trace-mapping@0.3.25:
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@keystonehq/bc-ur-registry-sol@0.3.1:
     resolution: {integrity: sha512-Okr5hwPxBZxB4EKLK1GSC9vsrh/tFMQ5dvs3EQ9NCOmCn7CXdXIMSeafrpGCHk484Jf5c6X0Wq0yf0VqY2A/8Q==}
@@ -10058,6 +10076,22 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
+  /@tsconfig/node10@1.0.11:
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
+
   /@types/argparse@1.0.38:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
     dev: true
@@ -12409,6 +12443,10 @@ packages:
     dev: false
     optional: true
 
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
+
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -14172,6 +14210,10 @@ packages:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
   /cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -14828,6 +14870,11 @@ packages:
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
     dev: true
 
   /diff@5.1.0:
@@ -19553,6 +19600,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       semver: 7.5.4
+    dev: true
+
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: true
 
   /make-fetch-happen@2.6.0:
@@ -25871,6 +25922,37 @@ packages:
   /ts-mixer@6.0.3:
     resolution: {integrity: sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ==}
 
+  /ts-node@10.9.2(@types/node@20.10.5)(typescript@5.4.2):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.10.5
+      acorn: 8.11.2
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
     dev: true
@@ -26583,6 +26665,10 @@ packages:
       sade: 1.8.1
     dev: true
 
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
+
   /v8-compile-cache@2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: true
@@ -26595,7 +26681,7 @@ packages:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
     dev: true
@@ -27534,6 +27620,11 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

参考@Wxh16144 大佬 pr(https://github.com/ant-design/ant-design-icons/pull/635), 实现了icon-preview(通过jsdoc, 鼠标放在组件上可以看到icon的样式)，因为打包方式、产物以及命名上有一些不同，所以在代码上略有改造。

这个同步脚本应该后续也用得上，略加改造同步 svg 可以提高后续添加 svg 的效率直接拖入图片就可以转成组件代码，降低cv和命名心智，

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/3c3997df-2296-4c86-a29f-8502cb9fc7ee)

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/dba541ac-1844-493a-9020-ac8c6c114c79)

目前部分目录会有点问题，佬们看看是需要重命名呢，还是跳过这些文件，还是完善正则去兼容。

<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->



<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
