### PR TITLE
feat(ether): support ether testnet 'Sepolia' 

### DIFF
--- a/.changeset/sweet-roses-drum.md
+++ b/.changeset/sweet-roses-drum.md
@@ -1,5 +1,5 @@
 ---
-"@ant-design/web3-assets": patch
+"@ant-design/web3-assets": minor
 ---
 
 feat(ethers): support ether testnet 'Sepolia'

--- a/.changeset/sweet-roses-drum.md
+++ b/.changeset/sweet-roses-drum.md
@@ -1,5 +1,5 @@
 ---
-"@ant-design/web3-assets": major
+"@ant-design/web3-assets": patch
 ---
 
 feat(ethers): support ether testnet 'Sepolia'

--- a/.changeset/sweet-roses-drum.md
+++ b/.changeset/sweet-roses-drum.md
@@ -1,0 +1,5 @@
+---
+"@ant-design/web3-assets": major
+---
+
+feat(ethers): support ether testnet 'Sepolia'

--- a/packages/assets/src/chains/ethereum.tsx
+++ b/packages/assets/src/chains/ethereum.tsx
@@ -41,7 +41,7 @@ export const Sepolia: Chain = {
     icon: <EthereumCircleColorful />,
     getBrowserLink: createGetBrowserLink('https://sepolia.etherscan.io'),
   },
-  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
 };
 
 export const Polygon: Chain = {

--- a/packages/assets/src/chains/ethereum.tsx
+++ b/packages/assets/src/chains/ethereum.tsx
@@ -33,6 +33,17 @@ export const Goerli: Chain = {
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
 };
 
+export const Sepolia: Chain = {
+  id: ChainIds.Sepolia,
+  name: 'Sepolia',
+  icon: <EthereumCircleColorful />,
+  browser: {
+    icon: <EthereumCircleColorful />,
+    getBrowserLink: createGetBrowserLink('https://sepolia.etherscan.io'),
+  },
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+};
+
 export const Polygon: Chain = {
   id: ChainIds.Polygon,
   name: 'Polygon',

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -12,7 +12,7 @@ export enum ChainIds {
   Goerli = 5,
   Avalanche = 43_114,
   X1Testnet = 195,
-  Sepolia = 11155111
+  Sepolia = 11_155_111
 }
 
 export enum SolanaChainIds {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -12,6 +12,7 @@ export enum ChainIds {
   Goerli = 5,
   Avalanche = 43_114,
   X1Testnet = 195,
+  Sepolia = 11155111
 }
 
 export enum SolanaChainIds {


### PR DESCRIPTION
## 💡 Background and solution

feat(ether): support ether testnet 'Sepolia' 

The ether testnet Sepolia is not currently supported in the code. The Goerli testnet is about to go offline, so add Sepolia support.

## 🔗 Related issue link
