### PR TITLE
chore: doc site supports mobile

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { en_US, Web3ConfigProvider, zh_CN } from '@ant-design/web3-common';
 import { useIntl, useLocation, useOutlet, usePrefersColor } from 'dumi';
+import { GlobalLayout as ThemeGlobalLayout } from 'dumi-theme-antd-web3';
 
 import SiteThemeProvider from '../SiteThemeProvider';
 
@@ -11,11 +12,13 @@ const GlobalLayout: React.FC = () => {
   const { locale } = useIntl();
 
   return (
-    <Web3ConfigProvider locale={locale === 'zh-CN' ? zh_CN : en_US}>
-      <SiteThemeProvider themeMode={color || 'auto'}>
-        <div className={pathname === '/' || pathname === '/index-cn' ? 'home' : ''}>{outlet}</div>
-      </SiteThemeProvider>
-    </Web3ConfigProvider>
+    <ThemeGlobalLayout>
+      <Web3ConfigProvider locale={locale === 'zh-CN' ? zh_CN : en_US}>
+        <SiteThemeProvider themeMode={color || 'auto'}>
+          <div className={pathname === '/' || pathname === '/index-cn' ? 'home' : ''}>{outlet}</div>
+        </SiteThemeProvider>
+      </Web3ConfigProvider>
+    </ThemeGlobalLayout>
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "babel-plugin-react-inline-svg-unique-id": "^1.4.0",
     "classnames": "^2.3.2",
     "dumi": "^2.2.17",
-    "dumi-theme-antd-web3": "0.3.14-bate.2",
+    "dumi-theme-antd-web3": "0.3.15",
     "eslint": "^8.57.0",
     "eslint-plugin-unused-imports": "^3.1.0",
     "ethers": "^6.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^2.2.17
         version: 2.2.17(@babel/core@7.24.3)(@types/node@20.10.5)(@types/react@18.2.73)(eslint@8.57.0)(prettier@3.2.5)(react-dom@18.2.0)(react@18.2.0)(stylelint@14.16.1)(typescript@5.4.4)(webpack@5.91.0)
       dumi-theme-antd-web3:
-        specifier: 0.3.14-bate.2
-        version: 0.3.14-bate.2(@babel/core@7.24.3)(@types/react@18.2.73)(antd@5.16.0)(dumi@2.2.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+        specifier: 0.3.15
+        version: 0.3.15(@babel/core@7.24.3)(@types/react@18.2.73)(antd@5.16.0)(dumi@2.2.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -15737,8 +15737,8 @@ packages:
     resolution: {integrity: sha512-a/Y5lf0G6gwsEQ9hop/n03CcjmHsGBk384Cz/AEX6mRYrfSpUx/lQvP9HLoXkCzScl9PL1sSmLPnMkgaXDCZLA==}
     dev: true
 
-  /dumi-theme-antd-web3@0.3.14-bate.2(@babel/core@7.24.3)(@types/react@18.2.73)(antd@5.16.0)(dumi@2.2.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-RxyFeVRNHe9sdWT4gf4sTm80HXhAJ5S2yb0jGGD3WYtMs0s6NwRyy++QP9A1/PASPh+Qk9lkfSNwTqbxuX5cPA==}
+  /dumi-theme-antd-web3@0.3.15(@babel/core@7.24.3)(@types/react@18.2.73)(antd@5.16.0)(dumi@2.2.17)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-m/VHW9RaIV+4u7ckA6LJ7+w/bDEBJEIbZfGotbREIlgtpKpBYDzVdYYPwpdYu33f/HQUHV3wlTakyvIe4Ash+g==}
     peerDependencies:
       antd: ~5.7.0
       dumi: ~2.2.17


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

项目中定义的 `GlobalLayout` 与主题中的相冲突，导致移动端适配逻辑未生效

## 🔗 Related issue link

Close #612
Close #745
