### PR TITLE
feat(solana): Support auto add registered wallets

### DIFF
--- a/.changeset/strong-wasps-serve.md
+++ b/.changeset/strong-wasps-serve.md
@@ -1,0 +1,5 @@
+---
+"@ant-design/web3-solana": minor
+---
+
+feat(solana): Support auto add installed wallets

--- a/packages/solana/src/solana-provider/config-provider.tsx
+++ b/packages/solana/src/solana-provider/config-provider.tsx
@@ -27,7 +27,7 @@ export interface AntDesignWeb3ConfigProviderProps {
   currentChain?: SolanaChainConfig;
   availableWallets: Wallet[];
   connectionError?: WalletConnectionError;
-  autoAddRegistedWallets?: boolean;
+  autoAddRegisteredWallets?: boolean;
   onCurrentChainChange?: (chain?: SolanaChainConfig) => void;
 }
 
@@ -157,7 +157,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<
       };
     });
 
-    if (!props.autoAddRegistedWallets) {
+    if (!props.autoAddRegisteredWallets) {
       return providedWallets;
     }
 
@@ -183,7 +183,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<
       });
 
     return [...providedWallets, ...autoRegisteredWallets];
-  }, [props.availableWallets, wallets, props.autoAddRegistedWallets]);
+  }, [props.availableWallets, wallets, props.autoAddRegisteredWallets]);
 
   const currentChain = useMemo(() => {
     return chainList.find((c) => c.id === props.currentChain?.id);

--- a/packages/solana/src/solana-provider/config-provider.tsx
+++ b/packages/solana/src/solana-provider/config-provider.tsx
@@ -27,6 +27,7 @@ export interface AntDesignWeb3ConfigProviderProps {
   currentChain?: SolanaChainConfig;
   availableWallets: Wallet[];
   connectionError?: WalletConnectionError;
+  autoAddRegistedWallets?: boolean;
   onCurrentChainChange?: (chain?: SolanaChainConfig) => void;
 }
 
@@ -137,7 +138,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<
   }, [props.availableChains, props.chainAssets]);
 
   const availableWallets = useMemo<Wallet[]>(() => {
-    return props.availableWallets.map((w) => {
+    const providedWallets = props.availableWallets.map<Wallet>((w) => {
       const adapter = wallets?.find((item) => item.adapter.name === w.name)?.adapter;
       const isWalletConnectAdapter = adapter instanceof WalletConnectWalletAdapter;
 
@@ -155,7 +156,34 @@ export const AntDesignWeb3ConfigProvider: React.FC<
         },
       };
     });
-  }, [props.availableWallets, wallets]);
+
+    if (!props.autoAddRegistedWallets) {
+      return providedWallets;
+    }
+
+    const providedWalletNames = providedWallets.map((w) => w.name);
+
+    const autoRegisteredWallets = wallets
+      .filter((w) => !providedWalletNames.includes(w.adapter.name))
+      .map<Wallet>((w) => {
+        const adapter = w.adapter;
+
+        return {
+          name: adapter.name,
+          icon: adapter.icon,
+          remark: adapter.name,
+
+          hasExtensionInstalled: async () => {
+            return adapter.readyState === WalletReadyState.Installed;
+          },
+          hasWalletReady: async () => {
+            return hasWalletReady(adapter.readyState);
+          },
+        };
+      });
+
+    return [...providedWallets, ...autoRegisteredWallets];
+  }, [props.availableWallets, wallets, props.autoAddRegistedWallets]);
 
   const currentChain = useMemo(() => {
     return chainList.find((c) => c.id === props.currentChain?.id);

--- a/packages/solana/src/solana-provider/index.tsx
+++ b/packages/solana/src/solana-provider/index.tsx
@@ -22,6 +22,8 @@ export interface SolanaWeb3ConfigProviderProps {
   wallets?: WalletFactory[];
   balance?: boolean;
 
+  autoAddRegistedWallets?: boolean;
+
   rpcProvider?: (chain?: SolanaChainConfig) => string;
 
   //#region Solana ConnectionProvider specific
@@ -45,6 +47,7 @@ export const SolanaWeb3ConfigProvider: FC<PropsWithChildren<SolanaWeb3ConfigProv
   connectionConfig,
   autoConnect,
   walletConnect,
+  autoAddRegistedWallets,
   children,
   walletProviderProps,
 }) => {
@@ -108,6 +111,7 @@ export const SolanaWeb3ConfigProvider: FC<PropsWithChildren<SolanaWeb3ConfigProv
           onCurrentChainChange={(chain) => setCurrentChain(chain)}
           availableChains={chains || [solana]}
           connectionError={connectionError}
+          autoAddRegistedWallets={autoAddRegistedWallets}
         >
           {children}
         </AntDesignWeb3ConfigProvider>

--- a/packages/solana/src/solana-provider/index.tsx
+++ b/packages/solana/src/solana-provider/index.tsx
@@ -22,7 +22,7 @@ export interface SolanaWeb3ConfigProviderProps {
   wallets?: WalletFactory[];
   balance?: boolean;
 
-  autoAddRegistedWallets?: boolean;
+  autoAddRegisteredWallets?: boolean;
 
   rpcProvider?: (chain?: SolanaChainConfig) => string;
 
@@ -47,7 +47,7 @@ export const SolanaWeb3ConfigProvider: FC<PropsWithChildren<SolanaWeb3ConfigProv
   connectionConfig,
   autoConnect,
   walletConnect,
-  autoAddRegistedWallets,
+  autoAddRegisteredWallets,
   children,
   walletProviderProps,
 }) => {
@@ -111,7 +111,7 @@ export const SolanaWeb3ConfigProvider: FC<PropsWithChildren<SolanaWeb3ConfigProv
           onCurrentChainChange={(chain) => setCurrentChain(chain)}
           availableChains={chains || [solana]}
           connectionError={connectionError}
-          autoAddRegistedWallets={autoAddRegistedWallets}
+          autoAddRegisteredWallets={autoAddRegisteredWallets}
         >
           {children}
         </AntDesignWeb3ConfigProvider>

--- a/packages/web3/src/solana/demos/recommend.tsx
+++ b/packages/web3/src/solana/demos/recommend.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import { ConnectButton, Connector } from '@ant-design/web3';
-import { SolanaWeb3ConfigProvider } from '@ant-design/web3-solana';
+import {
+  OKXWallet,
+  PhantomWallet,
+  SolanaWeb3ConfigProvider,
+  WalletConnectWallet,
+} from '@ant-design/web3-solana';
 
 const App: React.FC = () => {
   return (
-    <SolanaWeb3ConfigProvider autoAddRegistedWallets>
+    <SolanaWeb3ConfigProvider
+      autoAddRegisteredWallets
+      balance
+      wallets={[PhantomWallet(), OKXWallet(), WalletConnectWallet()]}
+      walletConnect={{ projectId: YOUR_WALLET_CONNECT_PROJECT_ID }}
+    >
       <Connector modalProps={{ mode: 'simple' }}>
         <ConnectButton quickConnect />
       </Connector>

--- a/packages/web3/src/solana/demos/recommend.tsx
+++ b/packages/web3/src/solana/demos/recommend.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { ConnectButton, Connector } from '@ant-design/web3';
+import { SolanaWeb3ConfigProvider } from '@ant-design/web3-solana';
+
+const App: React.FC = () => {
+  return (
+    <SolanaWeb3ConfigProvider autoAddRegistedWallets>
+      <Connector modalProps={{ mode: 'simple' }}>
+        <ConnectButton quickConnect />
+      </Connector>
+    </SolanaWeb3ConfigProvider>
+  );
+};
+
+export default App;

--- a/packages/web3/src/solana/index.md
+++ b/packages/web3/src/solana/index.md
@@ -9,6 +9,10 @@ group:
 
 Ant Design Web3 officially provides `@ant-design/web3-solana` to adapt to Solana. It is an Ant Design Web3 Solana adapter based on [Solana Web3.js](https://solana-labs.github.io/solana-web3.js/). It provides the ability to connect to Solana for the components of `@ant-design/web3`.
 
+## Recommended configuration
+
+<code src="./demos/recommend.tsx"></code>
+
 ## Basic Usage
 
 <code src="./demos/basic.tsx"></code>

--- a/packages/web3/src/solana/index.md
+++ b/packages/web3/src/solana/index.md
@@ -11,7 +11,17 @@ Ant Design Web3 officially provides `@ant-design/web3-solana` to adapt to Solana
 
 ## Recommended configuration
 
+We support rich configurations of wallets, protocols, and interaction methods. For most DApps, we recommend using the following configuration:
+
 <code src="./demos/recommend.tsx"></code>
+
+The recommended configuration mainly includes:
+
+- Supports automatically adding detected plugin wallets.
+- Supports displaying balance.
+- Adds Phantom and OKX wallets by default, providing download guidance if the user has not installed a wallet.
+- Configure `quickConnect` to provide quick connection entry to simplify user operations.
+- Uses `simple` mode to simplify the interface.
 
 ## Basic Usage
 
@@ -59,6 +69,7 @@ You can use more components together. The content related to the chain in the co
 | chains | Chains | SolanaChainConfig\[\] | - | - |
 | wallets | Wallets | WalletFactory\[\] | - | - |
 | autoConnect | Whether to connect automatically | `boolean` | `false` | - |
+| autoAddRegisteredWallets | Whether to automatically add registered plugin wallets | `boolean` | `false` | - |
 | walletProviderProps | Transparent to WalletProvider | [WalletProviderProps](https://github.com/solana-labs/wallet-adapter/blob/master/packages/core/react/src/WalletProvider.tsx#L17) | - | - |
 | locale | Multilingual settings | [Locale](https://github.com/ant-design/ant-design-web3/blob/main/packages/common/src/locale/zh_CN.ts) | - | - |
 | walletConnect | WalletConnect configs | [UniversalProviderOpts](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/providers/universal-provider/src/types/misc.ts#L9) | - | - |

--- a/packages/web3/src/solana/index.zh-CN.md
+++ b/packages/web3/src/solana/index.zh-CN.md
@@ -12,7 +12,17 @@ Ant Design Web3 官方提供了 `@ant-design/web3-solana` 来适配 Solana，它
 
 ## 推荐配置
 
+我们支持配置丰富的钱包、协议和交互方式，对于大部分 DApp 来说，我们基于对 DApp 用户的习惯分析，推荐使用如下配置：
+
 <code src="./demos/recommend.tsx"></code>
+
+该推荐配置主要包括：
+
+- 支持自动添加检测到的插件钱包。
+- 支持显示余额。
+- 默认添加 Phantom、OKX 钱包，在用户未安装钱包情况下提供下载引导。
+- 配置 `quickConnect`，提供快速连接入口，简化用户操作。
+- 使用 `simple` 模式，简化界面。
 
 ## 基本使用
 
@@ -60,6 +70,7 @@ Ant Design Web3 官方提供了 `@ant-design/web3-solana` 来适配 Solana，它
 | chains | 可用的链 | SolanaChainConfig\[\] | - | - |
 | wallets | 可用的钱包 | WalletFactory\[\] | - | - |
 | autoConnect | 是否自动连接 | `boolean` | `false` | - |
+| autoAddRegisteredWallets | 是否自动添加已注册的插件钱包 | `boolean` | `false` | - |
 | walletProviderProps | WalletProvider 的属性 | [WalletProviderProps](https://github.com/solana-labs/wallet-adapter/blob/master/packages/core/react/src/WalletProvider.tsx#L17) | - | - |
 | locale | 多语言设置 | [Locale](https://github.com/ant-design/ant-design-web3/blob/main/packages/common/src/locale/zh_CN.ts) | - | - |
 | walletConnect | WalletConnect 配置 | [UniversalProviderOpts](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/providers/universal-provider/src/types/misc.ts#L9) | - | - |

--- a/packages/web3/src/solana/index.zh-CN.md
+++ b/packages/web3/src/solana/index.zh-CN.md
@@ -10,6 +10,10 @@ group:
 
 Ant Design Web3 官方提供了 `@ant-design/web3-solana` 来适配 Solana，它是一个基于 [Solana Web3.js](https://solana-labs.github.io/solana-web3.js/) 的 Ant Design Web3 Solana 适配器。它为 `@ant-design/web3` 的组件提供了连接 Solana 的能力。
 
+## 推荐配置
+
+<code src="./demos/recommend.tsx"></code>
+
 ## 基本使用
 
 <code src="./demos/basic.tsx"></code>


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

可以自动将用户已经在浏览器安装插件的钱包添加到 Wallet Lists 中。

![image](https://github.com/ant-design/ant-design-web3/assets/18319675/dab18278-8f3a-42f4-ad70-c7435866edbe)

### API 变更
- 在 SolanaWeb3ConfigProvider 添加了一个 `autoAddRegisteredWallets` 属性，默认为 `false`
