### PR TITLE
style(connect-button): Use Flex instead of Space

### DIFF
--- a/.changeset/tough-items-leave.md
+++ b/.changeset/tough-items-leave.md
@@ -1,0 +1,5 @@
+---
+"@ant-design/web3": patch
+---
+
+style(connect-button): Use Flex instead of Space

--- a/packages/web3/src/connect-button/connect-button-inner.tsx
+++ b/packages/web3/src/connect-button/connect-button-inner.tsx
@@ -28,6 +28,7 @@ export const ConnectButtonInner: React.FC<ConnectButtonInnerProps> = (props) => 
     onConnectClick,
     intl,
     __hashId__,
+    className,
     ...restProps
   } = props;
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
@@ -110,6 +111,7 @@ export const ConnectButtonInner: React.FC<ConnectButtonInnerProps> = (props) => 
         menu={{
           items,
         }}
+        className={classNames(className, `${prefixCls}-quick-connect`)}
         onClick={(e) => {
           onClick?.(e);
           onConnectClick?.(firstInstallWallet);

--- a/packages/web3/src/connect-button/connect-button-inner.tsx
+++ b/packages/web3/src/connect-button/connect-button-inner.tsx
@@ -124,6 +124,7 @@ export const ConnectButtonInner: React.FC<ConnectButtonInnerProps> = (props) => 
       </Dropdown.Button>
     ) : (
       <Button
+        className={className}
         {...restProps}
         onClick={(e) => {
           onClick?.(e);

--- a/packages/web3/src/connect-button/connect-button-inner.tsx
+++ b/packages/web3/src/connect-button/connect-button-inner.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { MoreOutlined } from '@ant-design/icons';
 import type { Wallet } from '@ant-design/web3-common';
 import type { ButtonProps, MenuProps } from 'antd';
-import { Button, ConfigProvider, Dropdown, Flex, Space } from 'antd';
+import { Button, ConfigProvider, Dropdown, Space } from 'antd';
 import classNames from 'classnames';
 
 import type { IntlType } from '../hooks/useIntl';
@@ -39,14 +39,10 @@ export const ConnectButtonInner: React.FC<ConnectButtonInnerProps> = (props) => 
   const getWalletIcon = (wallet: Wallet) => {
     const icon = wallet.icon;
 
-    return typeof icon === 'string' ? (
-      <img
-        className={classNames(__hashId__, `${prefixCls}-quick-connect-icon`)}
-        src={icon}
-        alt={`${wallet.name} Icon`}
-      />
-    ) : (
-      icon
+    return (
+      <span className={classNames(__hashId__, `${prefixCls}-quick-connect-icon`)}>
+        {typeof icon === 'string' ? <img src={icon} alt={`${wallet.name} Icon`} /> : icon}
+      </span>
     );
   };
 
@@ -117,15 +113,13 @@ export const ConnectButtonInner: React.FC<ConnectButtonInnerProps> = (props) => 
           onConnectClick?.(firstInstallWallet);
         }}
       >
-        <Flex align="center" className={`${prefixCls}-quick-connect-inner`}>
-          {children}
-          {getWalletIcon(firstInstallWallet)}
-        </Flex>
+        {children}
+        {getWalletIcon(firstInstallWallet)}
       </Dropdown.Button>
     ) : (
       <Button
-        className={className}
         {...restProps}
+        className={className}
         onClick={(e) => {
           onClick?.(e);
           onConnectClick?.();

--- a/packages/web3/src/connect-button/connect-button-inner.tsx
+++ b/packages/web3/src/connect-button/connect-button-inner.tsx
@@ -115,7 +115,7 @@ export const ConnectButtonInner: React.FC<ConnectButtonInnerProps> = (props) => 
           onConnectClick?.(firstInstallWallet);
         }}
       >
-        <Flex align="center" gap={8}>
+        <Flex align="center" className={`${prefixCls}-quick-connect-inner`}>
           {children}
           {getWalletIcon(firstInstallWallet)}
         </Flex>

--- a/packages/web3/src/connect-button/connect-button-inner.tsx
+++ b/packages/web3/src/connect-button/connect-button-inner.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { MoreOutlined } from '@ant-design/icons';
 import type { Wallet } from '@ant-design/web3-common';
 import type { ButtonProps, MenuProps } from 'antd';
-import { Button, ConfigProvider, Dropdown, Space } from 'antd';
+import { Button, ConfigProvider, Dropdown, Flex, Space } from 'antd';
 import classNames from 'classnames';
 
 import type { IntlType } from '../hooks/useIntl';
@@ -35,12 +35,14 @@ export const ConnectButtonInner: React.FC<ConnectButtonInnerProps> = (props) => 
   const [firstInstallWallet, setFirstInstallWallet] = useState<Wallet | undefined>(undefined);
   const [items, setItems] = useState<MenuProps['items']>([]);
 
-  const getWalletIcon = (icon?: string | React.ReactNode) => {
+  const getWalletIcon = (wallet: Wallet) => {
+    const icon = wallet.icon;
+
     return typeof icon === 'string' ? (
       <img
         className={classNames(__hashId__, `${prefixCls}-quick-connect-icon`)}
         src={icon}
-        alt="Wallet Icon"
+        alt={`${wallet.name} Icon`}
       />
     ) : (
       icon
@@ -78,7 +80,7 @@ export const ConnectButtonInner: React.FC<ConnectButtonInnerProps> = (props) => 
     const newItems = allQuickWallets.map((item) => {
       return {
         key: item.name,
-        icon: getWalletIcon(item.icon),
+        icon: getWalletIcon(item),
         label: item.name,
         onClick: () => {
           onConnectClick?.(item);
@@ -113,10 +115,10 @@ export const ConnectButtonInner: React.FC<ConnectButtonInnerProps> = (props) => 
           onConnectClick?.(firstInstallWallet);
         }}
       >
-        <Space>
+        <Flex align="center" gap={8}>
           {children}
-          {getWalletIcon(firstInstallWallet?.icon)}
-        </Space>
+          {getWalletIcon(firstInstallWallet)}
+        </Flex>
       </Dropdown.Button>
     ) : (
       <Button

--- a/packages/web3/src/connect-button/style/index.ts
+++ b/packages/web3/src/connect-button/style/index.ts
@@ -56,12 +56,22 @@ const genConnectButtonStyle: GenerateStyle<ConnectButtonToken> = (token) => {
       padding: `4px 15px`,
     },
 
-    [`${token.componentCls}-quick-connect-inner`]: {
-      gap: 8,
+    [`${token.componentCls}-quick-connect`]: {
+      [`${token.componentCls}-quick-connect-icon`]: {
+        marginLeft: token.marginXS,
+      },
     },
+
     [`${token.componentCls}-quick-connect-icon`]: {
-      height: token.fontSize,
-      width: token.fontSize,
+      [`> ${token.antCls}icon`]: {
+        height: token.fontSize,
+        width: token.fontSize,
+      },
+
+      '> img': {
+        height: token.fontSize,
+        width: token.fontSize,
+      },
     },
 
     [`${token.componentCls}-profile-modal`]: {

--- a/packages/web3/src/connect-button/style/index.ts
+++ b/packages/web3/src/connect-button/style/index.ts
@@ -56,6 +56,9 @@ const genConnectButtonStyle: GenerateStyle<ConnectButtonToken> = (token) => {
       padding: `4px 15px`,
     },
 
+    [`${token.componentCls}-quick-connect-inner`]: {
+      gap: 8,
+    },
     [`${token.componentCls}-quick-connect-icon`]: {
       height: token.fontSize,
       width: token.fontSize,


### PR DESCRIPTION
## 💡 Background and solution

文本和图标水平对齐稍微有点歪，换成 Flex 比较好控制一点。

### 现状
---
| Chain | Preview | Note |
|:-|-|-|
| Ethereum | ![image](https://github.com/ant-design/ant-design-web3/assets/18319675/8bc44d82-c232-4517-91b5-4acb18ba0234) | 这里的图标中，<br />图片留白比较多，<br />实际内容部分（红色）比较小所以看不太出来。|
| Solana | ![image](https://github.com/ant-design/ant-design-web3/assets/18319675/6d0c1919-31a1-45aa-9d6e-56b7423299e0) | 这个图标红色部分是铺满的，看起来就比较明显。 |


--- 
### 优化后

|Ethereum| ![image](https://github.com/ant-design/ant-design-web3/assets/18319675/70003e9f-d3f0-4a21-b826-369f01631795) |
|-|-|
|**Solana**| ![image](https://github.com/ant-design/ant-design-web3/assets/18319675/6c23b739-f59a-4262-bee8-4616f1798708) |
