### PR TITLE
ci: lock pnpm@8.9.0 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: ci
         run: |
-          npm i pnpm -g
+          npm i pnpm@8.9.0 -g
           pnpm install
           pnpm run ci
 

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           export PUBLIC_PATH=/
           export BASE=/
-          npm i pnpm -g
+          npm i pnpm@8.9.0 -g
           pnpm install
           pnpm run build:docs
           rm -rf dist/\~demos/:id


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution
目前ci pnpm 和项目配置不一样会出错，需要版本号一致。
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/053c7b67-bf74-4b5c-8321-048fa690f3fd)

## 🔗 Related issue link


