### PR TITLE
fix: use copy-to-clipboard and antd Typography.text for fix Address c…

### DIFF
--- a/.changeset/famous-icons-begin.md
+++ b/.changeset/famous-icons-begin.md
@@ -1,0 +1,5 @@
+---
+"@ant-design/web3": patch
+---
+
+fix: use copy-to-clipboard and antd Typography.text for fix Address copy bug

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -49,13 +49,14 @@
     "@inline-svg-unique-id/react": "^1.2.3",
     "antd": "^5.16.0",
     "bs58": "^5.0.0",
-    "classnames": "^2.3.2"
+    "classnames": "^2.3.2",
+    "copy-to-clipboard": "^3.3.3"
   },
   "devDependencies": {
-    "@ant-design/web3-solana": "workspace:*",
     "@ant-design/web3-bitcoin": "workspace:*",
-    "@ant-design/web3-wagmi": "workspace:*",
     "@ant-design/web3-ethers": "workspace:*",
+    "@ant-design/web3-solana": "workspace:*",
+    "@ant-design/web3-wagmi": "workspace:*",
     "@types/react": "^18.2.78",
     "@types/react-dom": "^18.2.25",
     "father": "^4.4.0",

--- a/packages/web3/src/address/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/web3/src/address/__tests__/__snapshots__/index.test.tsx.snap
@@ -8,9 +8,11 @@ exports[`Address > display address with default format 1`] = `
     class="ant-space-item"
   >
     <span
-      class="ant-web3-address-text"
+      class="ant-typography css-dev-only-do-not-override-11xg00t"
     >
-      0x 21CD f097 4d53 a6e9 6eF0 5d7B 324a 9803 735f Fd3B
+      <span>
+        0x 21CD f097 4d53 a6e9 6eF0 5d7B 324a 9803 735f Fd3B
+      </span>
     </span>
   </div>
 </div>

--- a/packages/web3/src/address/index.tsx
+++ b/packages/web3/src/address/index.tsx
@@ -1,14 +1,13 @@
 import type { ReactNode } from 'react';
-import React, { isValidElement, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { CheckOutlined, CopyOutlined } from '@ant-design/icons';
+import React, { isValidElement, useContext, useEffect, useMemo, useRef } from 'react';
 import { type Locale } from '@ant-design/web3-common';
 import type { TooltipProps } from 'antd';
-import { ConfigProvider, Space, Tooltip } from 'antd';
+import { ConfigProvider, Space, Tooltip, Typography } from 'antd';
 import classNames from 'classnames';
 
 import { useProvider } from '../hooks';
 import useIntl from '../hooks/useIntl';
-import { fillWithPrefix, formatAddress, writeCopyText } from '../utils';
+import { fillWithPrefix, formatAddress } from '../utils';
 import { useStyle } from './style';
 
 export interface AddressProps {
@@ -41,7 +40,6 @@ export const Address: React.FC<React.PropsWithChildren<AddressProps>> = (props) 
   const { addressPrefix: addressPrefixContext } = useProvider();
   const prefixCls = getPrefixCls('web3-address');
   const { wrapSSR, hashId } = useStyle(prefixCls);
-  const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
   const { messages } = useIntl('Address', locale);
 
@@ -90,34 +88,25 @@ export const Address: React.FC<React.PropsWithChildren<AddressProps>> = (props) 
 
   const formattedAddress = mergedFormat(filledAddress);
 
-  const handleOutlinedChange = () => {
-    writeCopyText(filledAddress).then(() => {
-      setCopied(true);
-      timerRef.current = setTimeout(() => {
-        setCopied(false);
-      }, 2000);
-    });
-  };
-
   return wrapSSR(
     <Space className={classNames(prefixCls, hashId)}>
-      <Tooltip title={mergedTooltip()}>
-        <span className={`${prefixCls}-text`}>
+      <Typography.Text
+        copyable={
+          copyable
+            ? {
+                text: filledAddress,
+                tooltips: [messages.copyTips, messages.copiedTips],
+              }
+            : false
+        }
+      >
+        <Tooltip title={mergedTooltip()}>
           {children ??
             (isEllipsis
               ? `${filledAddress.slice(0, headClip)}...${filledAddress.slice(-tailClip)}`
               : formattedAddress)}
-        </span>
-      </Tooltip>
-      {copyable && (
-        <>
-          {copied ? (
-            <CheckOutlined title={messages.copiedTips} />
-          ) : (
-            <CopyOutlined title={messages.copyTips} onClick={handleOutlinedChange} />
-          )}
-        </>
-      )}
+        </Tooltip>
+      </Typography.Text>
     </Space>,
   );
 };

--- a/packages/web3/src/address/index.tsx
+++ b/packages/web3/src/address/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import React, { isValidElement, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { isValidElement, useContext, useMemo } from 'react';
 import { type Locale } from '@ant-design/web3-common';
 import type { TooltipProps } from 'antd';
 import { ConfigProvider, Space, Tooltip, Typography } from 'antd';
@@ -40,7 +40,6 @@ export const Address: React.FC<React.PropsWithChildren<AddressProps>> = (props) 
   const { addressPrefix: addressPrefixContext } = useProvider();
   const prefixCls = getPrefixCls('web3-address');
   const { wrapSSR, hashId } = useStyle(prefixCls);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
   const { messages } = useIntl('Address', locale);
 
   const mergedFormat = useMemo(() => {
@@ -61,14 +60,6 @@ export const Address: React.FC<React.PropsWithChildren<AddressProps>> = (props) 
           tailClip: 4,
         }
       : ellipsis;
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
-  }, []);
 
   if (!address) {
     return null;

--- a/packages/web3/src/connect-button/__tests__/__snapshots__/profile-modal.test.tsx.snap
+++ b/packages/web3/src/connect-button/__tests__/__snapshots__/profile-modal.test.tsx.snap
@@ -99,9 +99,11 @@ exports[`ProfileModal > match snapshot 1`] = `
                         class="ant-space-item"
                       >
                         <span
-                          class="ant-web3-address-text"
+                          class="ant-typography css-dev-only-do-not-override-11xg00t"
                         >
-                          0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B
+                          <span>
+                            0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B
+                          </span>
                         </span>
                       </div>
                     </div>

--- a/packages/web3/src/connect-button/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/packages/web3/src/connect-button/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -23,9 +23,11 @@ exports[`ConnectButton > should display formatted by custom formatter when pass 
                 class="ant-space-item"
               >
                 <span
-                  class="ant-web3-address-text"
+                  class="ant-typography css-dev-only-do-not-override-11xg00t"
                 >
-                  0x3ea2...7c18
+                  <span>
+                    0x3ea2...7c18
+                  </span>
                 </span>
               </div>
             </div>

--- a/packages/web3/src/connect-button/__tests__/connect.test.tsx
+++ b/packages/web3/src/connect-button/__tests__/connect.test.tsx
@@ -70,7 +70,7 @@ describe('ConnectButton connect', async () => {
     fireEvent.click(baseElement.querySelector('.custom-btn')!);
     await vi.waitFor(() => {
       expect(onClickCallFn).toBeCalled();
-      expect(baseElement.querySelector('.ant-web3-address-text')?.textContent).toBe(
+      expect(baseElement.querySelector('.ant-web3-address .ant-typography span')?.textContent).toBe(
         '0x1234...7890',
       );
     });

--- a/packages/web3/src/connect-button/__tests__/menu.test.tsx
+++ b/packages/web3/src/connect-button/__tests__/menu.test.tsx
@@ -3,8 +3,7 @@ import type { MenuItemType } from 'antd/es/menu/hooks/useItems';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ConnectButton } from '..';
-import { readCopyText } from '../../utils';
-import { mockClipboard } from '../../utils/test-utils';
+import { readCopyText } from '../../utils/test-utils';
 
 const menuItems: MenuItemType[] = [
   {
@@ -24,13 +23,10 @@ const menuItems: MenuItemType[] = [
 ];
 
 describe('ConnectButton', () => {
-  let resetMockClipboard: () => void;
   beforeEach(() => {
-    resetMockClipboard = mockClipboard();
     vi.useFakeTimers();
   });
   afterEach(() => {
-    resetMockClipboard();
     vi.useRealTimers();
   });
   it('Should show menu when hover button', async () => {

--- a/packages/web3/src/connect-button/__tests__/profile-modal.test.tsx
+++ b/packages/web3/src/connect-button/__tests__/profile-modal.test.tsx
@@ -1,22 +1,13 @@
 import { Polygon } from '@ant-design/web3-assets';
 import { fireEvent, render } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { ConnectButton } from '..';
 import useIntl from '../../hooks/useIntl';
-import { readCopyText } from '../../utils';
-import { mockClipboard } from '../../utils/test-utils';
+import { readCopyText } from '../../utils/test-utils';
 import { ProfileModal } from '../profile-modal';
 
 describe('ProfileModal', () => {
-  let resetMockClipboard: () => void;
-  beforeEach(() => {
-    resetMockClipboard = mockClipboard();
-  });
-  afterEach(() => {
-    resetMockClipboard();
-  });
-
   it('match snapshot', () => {
     const App = () => {
       const intl = useIntl('ConnectButton');

--- a/packages/web3/src/connect-button/__tests__/tooltip.test.tsx
+++ b/packages/web3/src/connect-button/__tests__/tooltip.test.tsx
@@ -2,18 +2,14 @@ import { fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ConnectButton } from '..';
-import { readCopyText } from '../../utils';
-import { mockClipboard } from '../../utils/test-utils';
+import { readCopyText } from '../../utils/test-utils';
 
 describe('ConnectButton', () => {
-  let resetMockClipboard: () => void;
   beforeEach(() => {
     vi.useFakeTimers();
-    resetMockClipboard = mockClipboard();
   });
   afterEach(() => {
     vi.useRealTimers();
-    resetMockClipboard();
   });
 
   it('when tooltip is boolean, ant-tooltip not toBeNull', async () => {
@@ -26,7 +22,7 @@ describe('ConnectButton', () => {
       );
     };
     const { baseElement, rerender } = render(<App />);
-    const btn = baseElement.querySelector('.ant-web3-address-text')!;
+    const btn = baseElement.querySelector('.ant-web3-address .ant-typography span')!;
     fireEvent.mouseEnter(btn);
     rerender(<App />);
     // When the tooltip's title is string, baseElement.outerHTML does not contain '.ant-tooltip'.

--- a/packages/web3/src/utils/__tests__/browser.test.ts
+++ b/packages/web3/src/utils/__tests__/browser.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { getPlatform, readCopyText, writeCopyText } from '../browser';
-import { browsers, mockBrowser, mockClipboard } from '../test-utils';
+import { getPlatform, writeCopyText } from '../browser';
+import { browsers, mockBrowser, readCopyText } from '../test-utils';
 
 describe('utils/browser', () => {
-  let resetMockClipboard: () => void;
   it('getPlatform', () => {
     Object.keys(browsers).forEach((key) => {
       const reset = mockBrowser(key);
@@ -14,10 +13,8 @@ describe('utils/browser', () => {
     expect(getPlatform()).toBe('Other');
   });
   it('writeCopyText & readCopyText', () => {
-    resetMockClipboard = mockClipboard();
     const test = 'test copy text';
     writeCopyText(test);
     expect(readCopyText()).resolves.toBe(test);
-    resetMockClipboard();
   });
 });

--- a/packages/web3/src/utils/browser.ts
+++ b/packages/web3/src/utils/browser.ts
@@ -1,3 +1,5 @@
+import copy from 'copy-to-clipboard';
+
 export const getPlatform = () => {
   const userAgent = navigator.userAgent.toLowerCase();
   if (userAgent.includes('chrome')) {
@@ -13,10 +15,6 @@ export const getPlatform = () => {
   }
 };
 
-export const writeCopyText = (text: string): Promise<void> => {
-  return navigator.clipboard.writeText(text);
-};
-
-export const readCopyText = (): Promise<string> => {
-  return navigator.clipboard.readText();
+export const writeCopyText = async (text: string): Promise<boolean> => {
+  return copy(text);
 };

--- a/packages/web3/src/utils/test-utils.ts
+++ b/packages/web3/src/utils/test-utils.ts
@@ -1,31 +1,8 @@
 import type { WalletExtensionItem } from '@ant-design/web3-common';
 
-const oriClipboard = window.navigator.clipboard;
-// 代理 navigator.clipboard 方法用于测试复制文本到粘贴板的功能
-export const mockClipboard = () => {
-  const clipboard = {
-    text: '',
-    writeText: (text: string) => {
-      clipboard.text = text;
-      return Promise.resolve();
-    },
-    readText: () => {
-      return Promise.resolve(clipboard.text);
-    },
-  };
-  Object.defineProperty(window, 'navigator', {
-    value: {
-      clipboard,
-    },
-  });
-
-  return () => {
-    Object.defineProperty(window, 'navigator', {
-      value: {
-        clipboard: oriClipboard,
-      },
-    });
-  };
+export const readCopyText = async (): Promise<string> => {
+  // @ts-ignore
+  return global.copiedText;
 };
 
 export const browsers: Record<WalletExtensionItem['key'], string> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,6 +513,9 @@ importers:
       classnames:
         specifier: ^2.3.2
         version: 2.3.2
+      copy-to-clipboard:
+        specifier: ^3.3.3
+        version: 3.3.3
       react:
         specifier: '>=17.0.0'
         version: 18.2.0
@@ -1218,7 +1221,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.24.0
-    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.23.6):
     resolution: {integrity: sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==}
@@ -5259,7 +5261,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.3
       '@babel/generator': 7.24.1
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.4
       '@babel/types': 7.24.0
       '@expo/config': 8.5.4
       '@expo/env': 0.2.2
@@ -7325,7 +7327,7 @@ packages:
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     dependencies:
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.4
       '@babel/preset-env': 7.23.6(@babel/core@7.24.3)
       flow-parser: 0.206.0
       glob: 7.2.3
@@ -19512,7 +19514,7 @@ packages:
       '@babel/preset-env': ^7.1.6
     dependencies:
       '@babel/core': 7.24.3
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.4
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.3)
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.3)
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.3)
@@ -19890,7 +19892,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -19908,7 +19909,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -19926,7 +19926,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -19944,7 +19943,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -20812,7 +20810,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.3
       '@babel/generator': 7.24.1
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.4
       '@babel/types': 7.24.0
       metro: 0.80.8
       metro-babel-transformer: 0.80.8
@@ -20836,7 +20834,7 @@ packages:
       '@babel/code-frame': 7.24.2
       '@babel/core': 7.24.3
       '@babel/generator': 7.24.1
-      '@babel/parser': 7.24.1
+      '@babel/parser': 7.24.4
       '@babel/template': 7.24.0
       '@babel/traverse': 7.24.1(supports-color@5.5.0)
       '@babel/types': 7.24.0

--- a/tests/copy-to-clipboard.ts
+++ b/tests/copy-to-clipboard.ts
@@ -1,0 +1,8 @@
+// mock copy-to-clipboard global, for test copy, config this file invitest.config.mts alias field
+// @ts-ignore
+global.copiedText = '__initial__copied__text__';
+
+export default (text: string) => {
+  // @ts-ignore
+  global.copiedText = text;
+};

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import util from 'util';
 import { cleanup } from '@testing-library/react';
-import { afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, vi } from 'vitest';
 
 /* eslint-disable global-require */
 if (typeof window !== 'undefined') {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { defineConfig } from 'vitest/config';
 import svgr from 'vite-plugin-svgr';
+import { defineConfig } from 'vitest/config';
 
 const resolve = (src: string) => {
   return path.resolve(__dirname, src);
@@ -18,25 +18,27 @@ export default defineConfig({
     }),
   ],
   resolve: {
-    alias: isDist? {
-      '@ant-design/web3': resolve('./packages/web3/dist/esm/index'),
-      '@ant-design/web3-icons': resolve('./packages/icons/dist/esm/index'),
-      '@ant-design/web3-assets/solana': resolve('./packages/assets/dist/esm/solana/index'),
-      '@ant-design/web3-assets': resolve('./packages/assets/dist/esm/index'),
-      '@ant-design/web3-wagmi': resolve('./packages/wagmi/dist/esm/index'),
-      '@ant-design/web3-ethers': resolve('./packages/ethers/dist/esm/index'),
-      '@ant-design/web3-solana': resolve('./packages/solana/dist/esm/index'),
-      '@ant-design/web3-common': resolve('./packages/common/dist/esm/index'),
-    } : {
-      '@ant-design/web3': resolve('./packages/web3/src/index'),
-      '@ant-design/web3-icons': resolve('./packages/icons/src/index'),
-      '@ant-design/web3-assets/solana': resolve('./packages/assets/src/solana/index'),
-      '@ant-design/web3-assets': resolve('./packages/assets/src/index'),
-      '@ant-design/web3-wagmi': resolve('./packages/wagmi/src/index'),
-      '@ant-design/web3-ethers': resolve('./packages/ethers/src/index'),
-      '@ant-design/web3-solana': resolve('./packages/solana/src/index'),
-      '@ant-design/web3-common': resolve('./packages/common/src/index'),
-    },
+    alias: isDist
+      ? {
+          '@ant-design/web3': resolve('./packages/web3/dist/esm/index'),
+          '@ant-design/web3-icons': resolve('./packages/icons/dist/esm/index'),
+          '@ant-design/web3-assets/solana': resolve('./packages/assets/dist/esm/solana/index'),
+          '@ant-design/web3-assets': resolve('./packages/assets/dist/esm/index'),
+          '@ant-design/web3-wagmi': resolve('./packages/wagmi/dist/esm/index'),
+          '@ant-design/web3-ethers': resolve('./packages/ethers/dist/esm/index'),
+          '@ant-design/web3-solana': resolve('./packages/solana/dist/esm/index'),
+          '@ant-design/web3-common': resolve('./packages/common/dist/esm/index'),
+        }
+      : {
+          '@ant-design/web3': resolve('./packages/web3/src/index'),
+          '@ant-design/web3-icons': resolve('./packages/icons/src/index'),
+          '@ant-design/web3-assets/solana': resolve('./packages/assets/src/solana/index'),
+          '@ant-design/web3-assets': resolve('./packages/assets/src/index'),
+          '@ant-design/web3-wagmi': resolve('./packages/wagmi/src/index'),
+          '@ant-design/web3-ethers': resolve('./packages/ethers/src/index'),
+          '@ant-design/web3-solana': resolve('./packages/solana/src/index'),
+          '@ant-design/web3-common': resolve('./packages/common/src/index'),
+        },
   },
   test: {
     environment: 'jsdom',
@@ -49,5 +51,8 @@ export default defineConfig({
       reporter: ['json-summary', ['text', { skipFull: true }], 'cobertura', 'html'],
     },
     testTimeout: 3e4,
+    alias: {
+      'copy-to-clipboard': resolve('./tests/copy-to-clipboard'),
+    },
   },
 });


### PR DESCRIPTION
…opy bug

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

之前的 Address 样式不对，copy 的兼容性也不够好，集成到项目中可能会报错。修改为 antd 的方案，使用 `copy-to-clipboard` 包。

before:

<img width="391" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/1061968/3e1eaa27-476e-474f-850d-4cffe094cbdf">

after:

<img width="446" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/1061968/a2371e07-f4a9-44b6-9556-5e2c70ce2782">


## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

无。
