### PR TITLE
feat: NFTCard add new prop errorRender

### DIFF
--- a/.changeset/long-eagles-brush.md
+++ b/.changeset/long-eagles-brush.md
@@ -1,0 +1,5 @@
+---
+"@ant-design/web3": minor
+---
+
+feat: NFTCard add new prop errorRender

--- a/packages/web3/src/nft-card/NFTCard.tsx
+++ b/packages/web3/src/nft-card/NFTCard.tsx
@@ -8,7 +8,7 @@ import {
   type Web3ConfigProviderProps,
 } from '@ant-design/web3-common';
 import type { ImageProps } from 'antd';
-import { Button, ConfigProvider, Divider, Image, Skeleton, Space, theme } from 'antd';
+import { Button, ConfigProvider, Divider, Image, Result, Skeleton, Space, theme } from 'antd';
 import classNames from 'classnames';
 
 import { CryptoPrice, type CryptoPriceProps } from '../crypto-price';
@@ -45,6 +45,7 @@ interface NFTCardProps {
   type?: 'default' | 'pithy';
   onActionClick?: () => void;
   locale?: Locale['NFTCard'];
+  errorRender?: (e: Error) => ReactNode;
 }
 
 const CardSkeleton: React.FC<PropsWithChildren<{ loading: boolean; prefixCls: string }>> = ({
@@ -82,11 +83,16 @@ const NFTCard: React.FC<NFTCardProps> = (props) => {
     onActionClick,
     getNFTMetadata,
     locale,
+    errorRender,
     ...metadataProps
   } = props;
   const { liked = false, totalLikes = 0, onLikeChange } = likeConfig || {};
   const { token } = useToken();
-  const { metadata, loading } = useNFT(address, parseNumberToBigint(tokenId), getNFTMetadata);
+  const { metadata, loading, error } = useNFT(
+    address,
+    parseNumberToBigint(tokenId),
+    getNFTMetadata,
+  );
   const {
     name = metadata?.name,
     image = metadata?.image,
@@ -207,11 +213,18 @@ const NFTCard: React.FC<NFTCardProps> = (props) => {
     </>
   );
 
+  const renderContent = () => {
+    if (error) {
+      return errorRender?.(error) || <Result status="warning" subTitle={error.message} />;
+    }
+    return content;
+  };
+
   return wrapSSR(
     <div className={mergeCls} style={style}>
       <div className={`${prefixCls}-inner`}>
         <CardSkeleton prefixCls={`${prefixCls}-skeleton`} loading={loading}>
-          {content}
+          {renderContent()}
         </CardSkeleton>
       </div>
     </div>,

--- a/packages/web3/src/nft-card/__tests__/action.test.tsx
+++ b/packages/web3/src/nft-card/__tests__/action.test.tsx
@@ -3,13 +3,18 @@ import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('NFTCard actions', () => {
-  it('render action and onActionClick work', () => {
+  it('render action and onActionClick work', async () => {
     const actionFn = vi.fn();
     const address = '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B';
     const tokenId = 123;
 
     const { baseElement } = render(
       <NFTCard
+        getNFTMetadata={async () => {
+          return {
+            image: 'https://ipfs.io/ipfs/QmXVH2TsfCXJ5pDM3cabHKW1Z7M6fAtu5yV6LuifVWPsoP',
+          };
+        }}
         address={address}
         tokenId={tokenId}
         actionText="ActionTest"
@@ -20,18 +25,27 @@ describe('NFTCard actions', () => {
         }}
       />,
     );
-    // Ensure the like and price elements are rendered
-    expect(baseElement.querySelector('.ant-web3-nft-card-action')?.textContent).toBe('ActionTest');
-    fireEvent.click(baseElement.querySelector('.ant-web3-nft-card-action .ant-btn')!);
-    expect(actionFn).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      // Ensure the like and price elements are rendered
+      expect(baseElement.querySelector('.ant-web3-nft-card-action')?.textContent).toBe(
+        'ActionTest',
+      );
+      fireEvent.click(baseElement.querySelector('.ant-web3-nft-card-action .ant-btn')!);
+      expect(actionFn).toHaveBeenCalled();
+    });
   });
-  it('render action and onActionClick work', () => {
+  it('render action and onActionClick work', async () => {
     const actionFn = vi.fn();
     const address = '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B';
     const tokenId = 123;
 
     const { baseElement } = render(
       <NFTCard
+        getNFTMetadata={async () => {
+          return {
+            image: 'https://ipfs.io/ipfs/QmXVH2TsfCXJ5pDM3cabHKW1Z7M6fAtu5yV6LuifVWPsoP',
+          };
+        }}
         address={address}
         tokenId={tokenId}
         showAction
@@ -41,9 +55,11 @@ describe('NFTCard actions', () => {
         }}
       />,
     );
-    // Ensure the like and price elements are rendered
-    expect(baseElement.querySelector('.ant-web3-nft-card-action')?.textContent).toBe('Buy Now');
-    fireEvent.click(baseElement.querySelector('.ant-web3-nft-card-action .ant-btn')!);
-    expect(actionFn).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      // Ensure the like and price elements are rendered
+      expect(baseElement.querySelector('.ant-web3-nft-card-action')?.textContent).toBe('Buy Now');
+      fireEvent.click(baseElement.querySelector('.ant-web3-nft-card-action .ant-btn')!);
+      expect(actionFn).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/web3/src/nft-card/__tests__/basic.test.tsx
+++ b/packages/web3/src/nft-card/__tests__/basic.test.tsx
@@ -259,7 +259,7 @@ describe('NFTCard', () => {
         getNFTMetadata={async () => {
           throw new Error('This is an error');
         }}
-        errorRender={(e) => <div className="custom-error">Custom Error {e.message}</div>}
+        errorRender={(e: Error) => <div className="custom-error">Custom Error {e.message}</div>}
         address="0x79fcdef22feed20eddacbb2587640e45491b757f"
         tokenId={42n}
       />,

--- a/packages/web3/src/nft-card/__tests__/basic.test.tsx
+++ b/packages/web3/src/nft-card/__tests__/basic.test.tsx
@@ -1,5 +1,5 @@
 import { NFTCard } from '@ant-design/web3';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('NFTCard', () => {
@@ -60,13 +60,16 @@ describe('NFTCard', () => {
     const tokenId = 123;
 
     const { baseElement } = render(
-      <NFTCard address={address} tokenId={tokenId} footer={<div>Additional information</div>} />,
+      <NFTCard
+        image="https://ipfs.io/ipfs/QmXVH2TsfCXJ5pDM3cabHKW1Z7M6fAtu5yV6LuifVWPsoP"
+        footer={<div>Additional information</div>}
+      />,
     );
 
     expect(baseElement.querySelector('.ant-web3-nft-card-footer')).toBeTruthy();
   });
 
-  it('render tokenId when `type` is default', () => {
+  it('render tokenId when `type` is default', async () => {
     const address = '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B';
     const tokenId = 123;
     const likeConfig = {
@@ -81,19 +84,28 @@ describe('NFTCard', () => {
         price={{
           value: 139999n,
         }}
+        getNFTMetadata={async () => {
+          return {
+            name: 'NFT Name',
+            description: 'NFT Description',
+            image: 'ipfs://QmXVH2TsfCXJ5pDM3cabHKW1Z7M6fAtu5yV6LuifVWPsoP',
+          };
+        }}
       />,
     );
 
-    expect(
-      baseElement.querySelector('.ant-web3-nft-card-content .ant-web3-nft-card-serial-number'),
-    ).toBeTruthy();
-    expect(
-      baseElement.querySelector('.ant-web3-nft-card-content .ant-web3-nft-card-serial-number')
-        ?.textContent,
-    ).toBe('#123');
+    await vi.waitFor(() => {
+      expect(
+        baseElement.querySelector('.ant-web3-nft-card-content .ant-web3-nft-card-serial-number'),
+      ).toBeTruthy();
+      expect(
+        baseElement.querySelector('.ant-web3-nft-card-content .ant-web3-nft-card-serial-number')
+          ?.textContent,
+      ).toBe('#123');
+    });
   });
 
-  it('render tokenId when `type` is pithy', () => {
+  it('render tokenId when `type` is pithy', async () => {
     const address = '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B';
     const tokenId = 123;
     const likeConfig = {
@@ -102,6 +114,11 @@ describe('NFTCard', () => {
 
     const { baseElement } = render(
       <NFTCard
+        getNFTMetadata={async () => {
+          return {
+            image: 'https://ipfs.io/ipfs/QmXVH2TsfCXJ5pDM3cabHKW1Z7M6fAtu5yV6LuifVWPsoP',
+          };
+        }}
         address={address}
         tokenId={tokenId}
         like={likeConfig}
@@ -111,14 +128,15 @@ describe('NFTCard', () => {
         }}
       />,
     );
-
-    expect(
-      baseElement.querySelector('.ant-web3-nft-card-body .ant-web3-nft-card-serial-number'),
-    ).toBeTruthy();
-    expect(
-      baseElement.querySelector('.ant-web3-nft-card-body .ant-web3-nft-card-serial-number')
-        ?.textContent,
-    ).toBe('No:123');
+    await vi.waitFor(() => {
+      expect(
+        baseElement.querySelector('.ant-web3-nft-card-body .ant-web3-nft-card-serial-number'),
+      ).toBeTruthy();
+      expect(
+        baseElement.querySelector('.ant-web3-nft-card-body .ant-web3-nft-card-serial-number')
+          ?.textContent,
+      ).toBe('No:123');
+    });
   });
 
   it('`tokenId` can not pass', () => {
@@ -200,6 +218,7 @@ describe('NFTCard', () => {
     expect(imgEle?.src).toBe(imageUrl);
     expect(imgEle?.alt).toBe('test');
   });
+
   it('render image when error image', async () => {
     const { baseElement } = render(<NFTCard image="" />);
 
@@ -214,6 +233,41 @@ describe('NFTCard', () => {
       expect(
         baseElement.querySelector('.ant-web3-nft-card-content .ant-image-img')?.getAttribute('src'),
       ).toBe('');
+    });
+  });
+
+  it('render warning result when request error', async () => {
+    const { baseElement } = render(
+      <NFTCard
+        getNFTMetadata={async () => {
+          throw new Error('This is an error');
+        }}
+        address="0x79fcdef22feed20eddacbb2587640e45491b757f"
+        tokenId={42n}
+      />,
+    );
+    await vi.waitFor(() => {
+      expect(baseElement.querySelector('.ant-result-subtitle')?.textContent).toBe(
+        'This is an error',
+      );
+    });
+  });
+
+  it('errorRender', async () => {
+    const { baseElement } = render(
+      <NFTCard
+        getNFTMetadata={async () => {
+          throw new Error('This is an error');
+        }}
+        errorRender={(e) => <div className="custom-error">Custom Error {e.message}</div>}
+        address="0x79fcdef22feed20eddacbb2587640e45491b757f"
+        tokenId={42n}
+      />,
+    );
+    await vi.waitFor(() => {
+      expect(baseElement.querySelector('.custom-error')?.textContent).toBe(
+        'Custom Error This is an error',
+      );
     });
   });
 

--- a/packages/web3/src/nft-card/__tests__/like.test.tsx
+++ b/packages/web3/src/nft-card/__tests__/like.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('NFTCard like', () => {
-  it('renders correctly with likeConfig and onLikeChange work', () => {
+  it('renders correctly with likeConfig and onLikeChange work', async () => {
     const likeFn = vi.fn();
     const address = '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B';
     const tokenId = 123;
@@ -15,6 +15,11 @@ describe('NFTCard like', () => {
 
     const { baseElement } = render(
       <NFTCard
+        getNFTMetadata={async () => {
+          return {
+            image: 'https://ipfs.io/ipfs/QmXVH2TsfCXJ5pDM3cabHKW1Z7M6fAtu5yV6LuifVWPsoP',
+          };
+        }}
         address={address}
         tokenId={tokenId}
         like={likeConfig}
@@ -23,14 +28,17 @@ describe('NFTCard like', () => {
         }}
       />,
     );
-    // Ensure the like and price elements are rendered
-    expect(baseElement.querySelector('.ant-web3-nft-card-like-value')).toBeTruthy();
-    expect(baseElement.querySelector('.ant-web3-crypto-price-balance')).toBeTruthy();
-    fireEvent.click(baseElement.querySelector('.ant-web3-nft-card-like-icon')!);
-    expect(likeFn).toHaveBeenCalled();
+
+    await vi.waitFor(() => {
+      // Ensure the like and price elements are rendered
+      expect(baseElement.querySelector('.ant-web3-nft-card-like-value')).toBeTruthy();
+      expect(baseElement.querySelector('.ant-web3-crypto-price-balance')).toBeTruthy();
+      fireEvent.click(baseElement.querySelector('.ant-web3-nft-card-like-icon')!);
+      expect(likeFn).toHaveBeenCalled();
+    });
   });
 
-  it('should controlled by user when not pass likeConfig.liked', () => {
+  it('should controlled by user when not pass likeConfig.liked', async () => {
     const likeFn = vi.fn();
     const address = '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B';
     const tokenId = 123;
@@ -41,6 +49,11 @@ describe('NFTCard like', () => {
 
     const { baseElement } = render(
       <NFTCard
+        getNFTMetadata={async () => {
+          return {
+            image: 'https://ipfs.io/ipfs/QmXVH2TsfCXJ5pDM3cabHKW1Z7M6fAtu5yV6LuifVWPsoP',
+          };
+        }}
         address={address}
         tokenId={tokenId}
         like={likeConfig}
@@ -49,10 +62,12 @@ describe('NFTCard like', () => {
         }}
       />,
     );
-    // Ensure the like and price elements are rendered
-    expect(baseElement.querySelector('.ant-web3-nft-card-like-value')).toBeTruthy();
-    expect(baseElement.querySelector('.ant-web3-crypto-price-balance')).toBeTruthy();
-    fireEvent.click(baseElement.querySelector('.ant-web3-nft-card-like-icon')!);
-    expect(likeFn).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      // Ensure the like and price elements are rendered
+      expect(baseElement.querySelector('.ant-web3-nft-card-like-value')).toBeTruthy();
+      expect(baseElement.querySelector('.ant-web3-crypto-price-balance')).toBeTruthy();
+      fireEvent.click(baseElement.querySelector('.ant-web3-nft-card-like-icon')!);
+      expect(likeFn).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/web3/src/nft-card/demos/error.tsx
+++ b/packages/web3/src/nft-card/demos/error.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { NFTCard } from '@ant-design/web3';
+import { Space } from 'antd';
+
+const App: React.FC = () => {
+  return (
+    <Space>
+      <NFTCard
+        style={{
+          height: 498,
+        }}
+        getNFTMetadata={async () => {
+          throw new Error('This is an error');
+        }}
+        address="0x79fcdef22feed20eddacbb2587640e45491b757f"
+        tokenId={42n}
+      />
+      <NFTCard
+        style={{
+          height: 498,
+        }}
+        getNFTMetadata={async () => {
+          throw new Error('This is an error');
+        }}
+        errorRender={(e) => e.message}
+        address="0x79fcdef22feed20eddacbb2587640e45491b757f"
+        tokenId={42n}
+      />
+      <NFTCard
+        name="My NFT"
+        tokenId={16}
+        description="This is description"
+        showAction
+        footer="This is footer"
+        image="errorimageurl"
+      />
+    </Space>
+  );
+};
+
+export default App;

--- a/packages/web3/src/nft-card/index.md
+++ b/packages/web3/src/nft-card/index.md
@@ -39,6 +39,7 @@ Components used to display NFTCard.
 | showAction | Whether to show the action button of the card | `boolean` | `true` | - |
 | type | The type of the card | `'default' \| 'pithy'` | `'default'` | - |
 | onActionClick | The callback when the action button of the card is clicked | `() => void` | - | - |
+| errorRender | The method to render when an error occurs | `(error: Error) => React.ReactNode` | - | - |
 | locale | Multilingual settings | `Locale["NFTCard"]` | - | - |
 
 The definition of `NFTMetadata` refers to the Ethereum ERC721 standard, see [NFTMetadata document](../types/index.md#nftmetadata) for details.

--- a/packages/web3/src/nft-card/index.md
+++ b/packages/web3/src/nft-card/index.md
@@ -39,7 +39,7 @@ Components used to display NFTCard.
 | showAction | Whether to show the action button of the card | `boolean` | `true` | - |
 | type | The type of the card | `'default' \| 'pithy'` | `'default'` | - |
 | onActionClick | The callback when the action button of the card is clicked | `() => void` | - | - |
-| errorRender | The method to render when an error occurs | `(error: Error) => React.ReactNode` | - | - |
+| errorRender | Rendering method for displaying exception information when NFT gets an exception | `(error: Error) => React.ReactNode` | - | - |
 | locale | Multilingual settings | `Locale["NFTCard"]` | - | - |
 
 The definition of `NFTMetadata` refers to the Ethereum ERC721 standard, see [NFTMetadata document](../types/index.md#nftmetadata) for details.

--- a/packages/web3/src/nft-card/index.zh-CN.md
+++ b/packages/web3/src/nft-card/index.zh-CN.md
@@ -44,7 +44,7 @@ group: 展示
 | showAction | 是否显示卡片的操作按钮 | `boolean` | `true` | - |
 | type | 卡片的类型 | `'default' \| 'pithy'` | `'default'` | - |
 | onActionClick | 点击卡片的操作按钮时的回调 | `() => void` | - | - |
-| errorRender | 错误时的渲染方法 | `(error: Error) => React.ReactNode` | - | - |
+| errorRender | NFT 获取异常时展示异常信息的渲染方法 | `(error: Error) => React.ReactNode` | - | - |
 | locale | 多语言设置 | `Locale["NFTCard"]` | - | - |
 
 `NFTMetadata` 的定义参考以太坊 ERC721 的标准，具体见 [NFTMetadata 文档](../types/index.zh-CN.md#nftmetadata)。

--- a/packages/web3/src/nft-card/index.zh-CN.md
+++ b/packages/web3/src/nft-card/index.zh-CN.md
@@ -20,6 +20,10 @@ group: 展示
 
 <code src="./demos/wagmi.tsx"></code>
 
+## 错误处理
+
+<code src="./demos/error.tsx"></code>
+
 ## API
 
 | 属性 | 描述 | 类型 | 默认值 | 版本 |
@@ -40,6 +44,7 @@ group: 展示
 | showAction | 是否显示卡片的操作按钮 | `boolean` | `true` | - |
 | type | 卡片的类型 | `'default' \| 'pithy'` | `'default'` | - |
 | onActionClick | 点击卡片的操作按钮时的回调 | `() => void` | - | - |
+| errorRender | 错误时的渲染方法 | `(error: Error) => React.ReactNode` | - | - |
 | locale | 多语言设置 | `Locale["NFTCard"]` | - | - |
 
 `NFTMetadata` 的定义参考以太坊 ERC721 的标准，具体见 [NFTMetadata 文档](../types/index.zh-CN.md#nftmetadata)。


### PR DESCRIPTION


## 💡 Background and solution

现在如果请求 NFT 信息错误会出现空白，显示不友好，加上错误提示。

before：

<img width="634" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/1061968/017d7006-5843-481c-9b2d-31d6578a6b7f">


after：

<img width="1181" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/1061968/75c6fdc4-84be-4368-bc25-a43e81d16d04">

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
