### PR TITLE
fix: useCallback for getNFTMetadata for avoid ‘Error: Maximum update depth exceeded’

### DIFF
--- a/.changeset/smart-gifts-hunt.md
+++ b/.changeset/smart-gifts-hunt.md
@@ -1,0 +1,5 @@
+---
+"@ant-design/web3-wagmi": patch
+---
+
+fix: useCallback for getNFTMetadata for avoid `Error: Maximum update depth exceeded`

--- a/packages/wagmi/src/wagmi-provider/config-provider.tsx
+++ b/packages/wagmi/src/wagmi-provider/config-provider.tsx
@@ -184,6 +184,12 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
 
   const currency = currentChain?.nativeCurrency;
 
+  const getNFTMetadataFunc = React.useCallback(
+    async ({ address: contractAddress, tokenId }: { address: string; tokenId: bigint }) =>
+      getNFTMetadata(config, contractAddress, tokenId, chain?.id),
+    [chain?.id],
+  );
+
   return (
     <Web3ConfigProvider
       locale={locale}
@@ -228,9 +234,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
           chainId: c.id,
         });
       }}
-      getNFTMetadata={async ({ address: contractAddress, tokenId }) =>
-        getNFTMetadata(config, contractAddress, tokenId, chain?.id)
-      }
+      getNFTMetadata={getNFTMetadataFunc}
     >
       {children}
     </Web3ConfigProvider>


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

NFTCard 渲染的时候可能会出现 Error: Maximum update depth exceeded  这样的错误，原因是 getNFTMetadata 方法每次生成的引用都不同，导致 react 重复渲染

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
