### PR TITLE
refactor: remove useIntl for connect-modal demos

### DIFF
--- a/packages/web3/src/connect-modal/demos/basic.tsx
+++ b/packages/web3/src/connect-modal/demos/basic.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ConnectModal } from '@ant-design/web3';
 import { metadata_MetaMask, metadata_WalletConnect } from '@ant-design/web3-assets';
 import { Button } from 'antd';
-import { useIntl } from 'dumi';
 
 import type { Wallet } from '../interface';
 
@@ -62,7 +61,6 @@ const groupOrder = (a: string, b: string) => {
 
 const App: React.FC = () => {
   const [open, setOpen] = React.useState(false);
-  const { locale } = useIntl();
   return (
     <>
       <Button type="primary" onClick={() => setOpen(true)}>
@@ -70,7 +68,7 @@ const App: React.FC = () => {
       </Button>
       <ConnectModal
         open={open}
-        footer={locale === 'zh-CN' ? '蚂蚁链提供技术支持' : 'Powered by AntChain'}
+        footer={'Powered by AntChain'}
         group={{
           groupOrder,
         }}

--- a/packages/web3/src/connect-modal/demos/ungroupedBasic.tsx
+++ b/packages/web3/src/connect-modal/demos/ungroupedBasic.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ConnectModal } from '@ant-design/web3';
 import { metadata_MetaMask, metadata_WalletConnect } from '@ant-design/web3-assets';
 import { Button } from 'antd';
-import { useIntl } from 'dumi';
 
 import type { Wallet } from '../interface';
 
@@ -49,7 +48,6 @@ const walletList: Wallet[] = [
 
 const App: React.FC = () => {
   const [open, setOpen] = React.useState(false);
-  const { locale } = useIntl();
   return (
     <>
       <Button type="primary" onClick={() => setOpen(true)}>
@@ -57,7 +55,7 @@ const App: React.FC = () => {
       </Button>
       <ConnectModal
         open={open}
-        footer={locale === 'zh-CN' ? '蚂蚁链提供技术支持' : 'Powered by AntChain'}
+        footer={'Powered by AntChain'}
         walletList={walletList}
         onCancel={() => setOpen(false)}
         group={false}


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution
dumi2.3.2 useIntl 变成运行导出了，tmp文件中导出的useIntl, 这一块build的ci会过不去。不过感觉
```import { useIntl } from 'dumi';```用在demo是不是也不太合适，用户应该用自己的方法去判断国际化，或者说复制过去能马上能运行的，不然还得安装个dumi才能用这个。
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/532e5cad-5d02-4833-979f-86ee8e3db81c)
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/8e72d6c2-bb3f-4ef3-ace6-dd96372e680e)
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/0720eb26-2cc3-458d-a009-892fc098dcc2)



