### PR TITLE
docs: update doc detail

### DIFF
--- a/packages/web3/src/bitcoin/demos/basic.tsx
+++ b/packages/web3/src/bitcoin/demos/basic.tsx
@@ -4,7 +4,12 @@ import { BitcoinWeb3ConfigProvider, UnisatWallet, XverseWallet } from '@ant-desi
 const App: React.FC = () => {
   return (
     <BitcoinWeb3ConfigProvider wallets={[XverseWallet(), UnisatWallet()]}>
-      <Connector>
+      <Connector
+        modalProps={{
+          group: false,
+          mode: 'simple',
+        }}
+      >
         <ConnectButton />
       </Connector>
     </BitcoinWeb3ConfigProvider>

--- a/packages/web3/src/connect-button/index.md
+++ b/packages/web3/src/connect-button/index.md
@@ -1,7 +1,6 @@
 ---
 nav: Components
 group: UI Components
-order: 1
 ---
 
 # ConnectButton

--- a/packages/web3/src/connect-button/index.zh-CN.md
+++ b/packages/web3/src/connect-button/index.zh-CN.md
@@ -2,7 +2,6 @@
 nav: 组件
 subtitle: 连接钱包按钮
 group: UI 组件
-order: 1
 ---
 
 # ConnectButton

--- a/packages/web3/src/connect-modal/index.md
+++ b/packages/web3/src/connect-modal/index.md
@@ -1,7 +1,6 @@
 ---
 nav: Components
 group: UI Components
-order: 2
 ---
 
 # ConnectModal

--- a/packages/web3/src/connect-modal/index.zh-CN.md
+++ b/packages/web3/src/connect-modal/index.zh-CN.md
@@ -2,7 +2,6 @@
 nav: 组件
 subtitle: 连接钱包弹窗
 group: UI 组件
-order: 2
 ---
 
 # ConnectModal

--- a/packages/web3/src/connector/index.md
+++ b/packages/web3/src/connector/index.md
@@ -1,9 +1,6 @@
 ---
 nav: Components
-group:
-  title: UI Components
-  order: 2
-order: 0
+group: UI Components
 ---
 
 # Connector

--- a/packages/web3/src/connector/index.zh-CN.md
+++ b/packages/web3/src/connector/index.zh-CN.md
@@ -1,10 +1,7 @@
 ---
 nav: 组件
 subtitle: 连接器
-group:
-  title: UI 组件
-  order: 2
-order: 0
+group: UI 组件
 ---
 
 # Connector

--- a/packages/web3/src/solana/demos/recommend.tsx
+++ b/packages/web3/src/solana/demos/recommend.tsx
@@ -15,7 +15,7 @@ const App: React.FC = () => {
       wallets={[PhantomWallet(), OKXWallet(), WalletConnectWallet()]}
       walletConnect={{ projectId: YOUR_WALLET_CONNECT_PROJECT_ID }}
     >
-      <Connector modalProps={{ mode: 'simple' }}>
+      <Connector modalProps={{ mode: 'simple', group: false }}>
         <ConnectButton quickConnect />
       </Connector>
     </SolanaWeb3ConfigProvider>

--- a/packages/web3/src/solana/index.md
+++ b/packages/web3/src/solana/index.md
@@ -21,7 +21,7 @@ The recommended configuration mainly includes:
 - Supports displaying balance.
 - Adds Phantom and OKX wallets by default, providing download guidance if the user has not installed a wallet.
 - Configure `quickConnect` to provide quick connection entry to simplify user operations.
-- Uses `simple` mode to simplify the interface.
+- Uses `simple` mode and disable group to simplify the interface.
 
 ## Basic Usage
 

--- a/packages/web3/src/solana/index.zh-CN.md
+++ b/packages/web3/src/solana/index.zh-CN.md
@@ -22,7 +22,7 @@ Ant Design Web3 官方提供了 `@ant-design/web3-solana` 来适配 Solana，它
 - 支持显示余额。
 - 默认添加 Phantom、OKX 钱包，在用户未安装钱包情况下提供下载引导。
 - 配置 `quickConnect`，提供快速连接入口，简化用户操作。
-- 使用 `simple` 模式，简化界面。
+- 使用 `simple` 模式，去掉钱包分组，简化界面。
 
 ## 基本使用
 


### PR DESCRIPTION
- 修复组件文档排序的问题，去掉之前指定的排序，默认会按照首字母排序
- Solana 和 Bitcoin 第一个 demo 中配置 group 为 false，因为他们默认的钱包都是在一个分组