### PR TITLE
feat: Connector support onConnectError

### DIFF
--- a/.changeset/rotten-badgers-wait.md
+++ b/.changeset/rotten-badgers-wait.md
@@ -1,0 +1,5 @@
+---
+"@ant-design/web3": minor
+---
+
+feat: Connector support onConnectError

--- a/packages/web3/src/connector/__tests__/basic.test.tsx
+++ b/packages/web3/src/connector/__tests__/basic.test.tsx
@@ -342,6 +342,7 @@ describe('Connector', () => {
           ]}
           connect={async () => {
             return new Promise((resove, reject) => {
+              // throw an error but not reason
               reject();
             });
           }}

--- a/packages/web3/src/connector/connector.tsx
+++ b/packages/web3/src/connector/connector.tsx
@@ -15,6 +15,7 @@ export const Connector: React.FC<ConnectorProps> = (props) => {
     onDisconnect,
     onDisconnected,
     onChainSwitched,
+    onConnectError,
   } = props;
   const {
     availableWallets,
@@ -41,8 +42,12 @@ export const Connector: React.FC<ConnectorProps> = (props) => {
       onConnected?.();
       setOpen(false);
     } catch (e: any) {
-      messageApi.error(e.message);
-      console.error(e);
+      if (typeof onConnectError === 'function') {
+        onConnectError(e);
+      } else {
+        messageApi.error(e.message);
+        console.error(e);
+      }
     } finally {
       setLoading(false);
     }

--- a/packages/web3/src/connector/interface.ts
+++ b/packages/web3/src/connector/interface.ts
@@ -9,6 +9,7 @@ export interface ConnectorProps {
   onConnected?: () => void;
   onDisconnected?: () => void;
   onChainSwitched?: (chain?: Chain) => void;
+  onConnectError?: (error?: Error) => void;
 
   account?: Account;
   chain?: Chain;


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

有些钱包在连接失败时，抛出的异常中没有 message，这种情况目前只会提示一个：
![image](https://github.com/ant-design/ant-design-web3/assets/18319675/8f0f77c4-4156-4f2a-9205-66e400046526)

（目前只在使用 Solana 的一些钱包时出现。）

这个 pr 在 Connector 中添加了 onConnectError 属性，便于让开发者自己处理连接失败情况。

```tsx
<Connector
  onConnectError={(error) => {
    message.error(error?.message || 'Connect Error');
  }}
>
  <ConnectButton />
</Connector>
```

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
