### PR TITLE
refactor: import for bitcoin adapter

### DIFF
--- a/.changeset/funny-garlics-fly.md
+++ b/.changeset/funny-garlics-fly.md
@@ -1,0 +1,5 @@
+---
+"@ant-design/web3-bitcoin": patch
+---
+
+refactor: import for bitcoin adapter

--- a/packages/bitcoin/src/adapter/useBitcoinWallet.ts
+++ b/packages/bitcoin/src/adapter/useBitcoinWallet.ts
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import React from 'react';
 import type { Account, Balance } from '@ant-design/web3-common';
 
 export interface BitcoinWallet {
@@ -15,9 +15,9 @@ export interface BitcoinWallet {
   ) => Promise<string | undefined>;
 }
 
-export const BitcoinAdapterContext = createContext<BitcoinWallet>({} as BitcoinWallet);
+export const BitcoinAdapterContext = React.createContext<BitcoinWallet>({} as BitcoinWallet);
 
 export const useBitcoinWallet = () => {
-  const adapter = useContext(BitcoinAdapterContext);
+  const adapter = React.useContext(BitcoinAdapterContext);
   return adapter;
 };


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution
重构引入原因如下：

引入React不使用，容易被格式化插件去掉，但是一但去掉会出现错误 
```如果没有引用 "packages/common/node_modules/@types/react/ts5.0"，则无法命名 "BitcoinAdapterContext" 的推断类型。这很可能不可移植。需要类型注释。ts(2742)```
<img width="1224" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/326acd5f-7a31-4182-8424-69c169dd1fba">

<img width="566" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/117748716/50d5656b-235a-4468-8e79-f89ce0c517a1">

