### PR TITLE
fix: Update Solidity tutorial link

### DIFF
--- a/docs/course/advanced-more.zh-CN.md
+++ b/docs/course/advanced-more.zh-CN.md
@@ -10,6 +10,6 @@ order: 1
 
 学完 Ant Design Web3 入门课程后，对 DApp 开发感兴趣的同学可以继续深入学习更多课程。
 
-你可以在 [WTF Academy](https://www.wtf.academy/) 找到更多课程内容，比如如果你想要学习如何开发 Solidity 合约，你可以学习 [Solidity 入门课程](https://www.wtf.academy/solidity-start)。
+你可以在 [WTF Academy](https://www.wtf.academy/) 找到更多课程内容，比如如果你想要学习如何开发 Solidity 合约，你可以学习 [Solidity 入门课程](https://www.wtf.academy/courses)。
 
 另外我们正在和 [WTF Academy](https://www.wtf.academy/) 一起开发进阶的 [DApp 研发课程](https://github.com/WTFAcademy/WTF-Dapp)，也欢迎关注。


### PR DESCRIPTION
Solidity 官网教程网址变更，原网址 /solidity-start 已失效