### PR TITLE
docs: add error demo to en docs

### DIFF
--- a/packages/web3/src/nft-card/index.md
+++ b/packages/web3/src/nft-card/index.md
@@ -19,6 +19,10 @@ Components used to display NFTCard.
 
 <code src="./demos/wagmi.tsx"></code>
 
+## Error Handling
+
+<code src="./demos/error.tsx"></code>
+
 ## API
 
 | Property | Description | Type | Default | Version |


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

英文文档缺少一个 demo

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
