### PR TITLE
fix: set sideEffects false for enable treeshaking

### DIFF
--- a/.changeset/great-otters-doubt.md
+++ b/.changeset/great-otters-doubt.md
@@ -3,6 +3,7 @@
 "@ant-design/web3-assets": patch
 "@ant-design/web3-common": patch
 "@ant-design/web3-ethers": patch
+"@ant-design/web3-ethers-v5": patch
 "@ant-design/web3-solana": patch
 "@ant-design/web3-wagmi": patch
 "@ant-design/web3": patch

--- a/.changeset/great-otters-doubt.md
+++ b/.changeset/great-otters-doubt.md
@@ -1,0 +1,11 @@
+---
+"@ant-design/web3-bitcoin": patch
+"@ant-design/web3-assets": patch
+"@ant-design/web3-common": patch
+"@ant-design/web3-ethers": patch
+"@ant-design/web3-solana": patch
+"@ant-design/web3-wagmi": patch
+"@ant-design/web3": patch
+---
+
+fix: set sideEffects false for enable treeshaking

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -22,6 +22,7 @@
       "types": "./dist/esm/solana/index.d.ts"
     }
   },
+  "sideEffects": false,
   "typesVersions": {
     "*": {
       "solana": [

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -9,6 +9,7 @@
     "require": "./dist/lib/index.js",
     "types": "./dist/esm/index.d.ts"
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -10,6 +10,7 @@
     "require": "./dist/lib/index.js",
     "types": "./dist/esm/index.d.ts"
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/ethers-v5/package.json
+++ b/packages/ethers-v5/package.json
@@ -17,6 +17,7 @@
       "types": "./dist/esm/wagmi.d.ts"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -27,6 +27,7 @@
       "types": "./dist/esm/wagmi.d.ts"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -9,6 +9,7 @@
     "require": "./dist/lib/index.js",
     "types": "./dist/esm/index.d.ts"
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -10,6 +10,7 @@
     "require": "./dist/lib/index.js",
     "types": "./dist/esm/index.d.ts"
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "CHANGELOG.md",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -10,6 +10,7 @@
     "require": "./dist/lib/index.js",
     "types": "./dist/esm/index.d.ts"
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "CHANGELOG.md",


### PR DESCRIPTION

## 💡 Background and solution

除了 web3-icons 以外，其它包也都需要支持 treeshaking

## 🔗 Related issue link

https://github.com/ant-design/ant-design-web3/pull/858
