### PR TITLE
refactor: remove useless proxyConnectorName

### DIFF
--- a/.changeset/silly-schools-return.md
+++ b/.changeset/silly-schools-return.md
@@ -1,0 +1,8 @@
+---
+'@ant-design/web3-assets': patch
+'@ant-design/web3-common': patch
+'@ant-design/web3-wagmi': patch
+'@ant-design/web3': patch
+---
+
+refactor: remove useless proxyConnectorName

--- a/packages/assets/src/wallets/mobile-wallet.tsx
+++ b/packages/assets/src/wallets/mobile-wallet.tsx
@@ -8,5 +8,4 @@ export const metadata_MobileConnect: WalletMetadata = {
   universalProtocol: {
     link: 'https://walletconnect.com/',
   },
-  proxyConnectorName: 'WalletConnect',
 };

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -194,12 +194,6 @@ export type WalletMetadata = {
   universalProtocol?: {
     link: string;
   };
-
-  /**
-   * @desc 代理连接使用的名称
-   * @descEn The name used for proxy connection
-   */
-  proxyConnectorName?: string;
 };
 
 export type Balance = BalanceMetadata & {

--- a/packages/wagmi/src/wagmi-provider/config-provider.tsx
+++ b/packages/wagmi/src/wagmi-provider/config-provider.tsx
@@ -204,7 +204,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
       connect={async (wallet, options) => {
         let connector = await (wallet as WalletUseInWagmiAdapter)?.getWagmiConnector?.(options);
         if (!connector && wallet) {
-          connector = findConnectorByName(wallet?.proxyConnectorName ?? wallet.name);
+          connector = findConnectorByName(wallet.name);
         }
         if (!connector) {
           throw new Error(`Can not find connector for ${wallet?.name}`);

--- a/packages/wagmi/src/wallets/wallet-connect.ts
+++ b/packages/wagmi/src/wallets/wallet-connect.ts
@@ -1,8 +1,8 @@
 import { metadata_WalletConnect } from '@ant-design/web3-assets';
-import type { Wallet, WalletMetadata } from '@ant-design/web3-common';
+import type { WalletMetadata } from '@ant-design/web3-common';
 import type { Connector } from 'wagmi';
 
-import type { WalletFactory } from '../interface';
+import type { WalletFactory, WalletUseInWagmiAdapter } from '../interface';
 
 export type EthereumWalletConnect = (
   metadata?: Partial<WalletMetadata> & {
@@ -14,7 +14,7 @@ export const WalletConnect: EthereumWalletConnect = (metadata) => {
   const { useWalletConnectOfficialModal = false, ...rest } = metadata || {};
   return {
     connectors: ['WalletConnect'],
-    create: (connectors?: readonly Connector[]): Wallet => {
+    create: (connectors?: readonly Connector[]): WalletUseInWagmiAdapter => {
       let qrCodeUri: string | undefined = undefined;
       const getQrCode = async () => {
         const provider = await connectors?.[0]?.getProvider();
@@ -35,6 +35,9 @@ export const WalletConnect: EthereumWalletConnect = (metadata) => {
       };
       return {
         ...metadata_WalletConnect,
+        getWagmiConnector: async () => {
+          return connectors?.[0];
+        },
         hasWalletReady: async () => {
           return true;
         },

--- a/packages/web3/src/ethereum/demos/more-wallets.tsx
+++ b/packages/web3/src/ethereum/demos/more-wallets.tsx
@@ -40,15 +40,17 @@ const App: React.FC = () => {
       }}
       wallets={[
         MetaMask(),
-        WalletConnect(),
         TokenPocket({
           group: 'Popular',
         }),
+        MobileWallet({
+          group: 'Popular',
+        }),
+        WalletConnect(),
         CoinbaseWallet(),
         SafeheronWallet(),
         OkxWallet(),
         ImToken(),
-        MobileWallet(),
       ]}
       config={config}
     >


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

在 MobileWallet 实现中新增的 proxyConnectorName 不是必须的，可以去掉。MobileWallet 基于 WalletConnect 实现的，这个 PR 给 WalletConnect 加了 getWagmiConnector，这样就不需要用名字来找 Connector 了。

## 🔗 Related issue link

https://github.com/ant-design/ant-design-web3/pull/900