### PR TITLE
fix(ethers): useEthersSigner hook issue when chain not contain

### DIFF
--- a/.changeset/cuddly-countries-deliver.md
+++ b/.changeset/cuddly-countries-deliver.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3-ethers': patch
+---
+
+fix(ethers): useEthersSigner hook issue when chain not contain

--- a/packages/ethers/src/hooks/use-ethers-signer.ts
+++ b/packages/ethers/src/hooks/use-ethers-signer.ts
@@ -5,11 +5,13 @@ import { useConnectorClient, type Config } from 'wagmi';
 
 export function clientToSigner(client: Client<Transport, Chain, Account>) {
   const { account, chain, transport } = client;
-  const network = {
-    chainId: chain.id,
-    name: chain.name,
-    ensAddress: chain.contracts?.ensRegistry?.address,
-  };
+  const network = chain
+    ? {
+        chainId: chain.id,
+        name: chain.name,
+        ensAddress: chain.contracts?.ensRegistry?.address,
+      }
+    : undefined;
   const provider = new BrowserProvider(transport, network);
   const signer = new JsonRpcSigner(provider, account.address);
   return signer;


### PR DESCRIPTION
修复 ethers 包内部的一个问题，当钱包连接了一个未被当前项目定义的 chain 时，`client.chain` 为 null