### PR TITLE
feat: onConnected callback support provider account

### DIFF
--- a/.changeset/serious-ducks-jog.md
+++ b/.changeset/serious-ducks-jog.md
@@ -1,0 +1,7 @@
+---
+'@ant-design/web3-common': minor
+'@ant-design/web3-wagmi': minor
+'@ant-design/web3': minor
+---
+
+feat: onConnected callback support provider account

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -99,7 +99,7 @@ export interface UniversalWeb3ProviderInterface {
   /** Such as `0x` */
   addressPrefix?: string | false;
 
-  connect?: (wallet?: Wallet, options?: ConnectOptions) => Promise<void>;
+  connect?: (wallet?: Wallet, options?: ConnectOptions) => Promise<void | Account>;
   disconnect?: () => Promise<void>;
   switchChain?: (chain: Chain) => Promise<void>;
 

--- a/packages/wagmi/src/wagmi-provider/__tests__/config-with-eip6963-and-wallets.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/config-with-eip6963-and-wallets.test.tsx
@@ -17,6 +17,7 @@ vi.mock('wagmi', async () => {
       return {
         connectAsync: async (...args: any[]) => {
           mockConnectAsync(...args);
+          return {};
         },
       };
     },

--- a/packages/wagmi/src/wagmi-provider/__tests__/config-with-eip6963-wallet.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/config-with-eip6963-wallet.test.tsx
@@ -83,6 +83,7 @@ describe('WagmiWeb3ConfigProvider with EIP6963 Wallet', () => {
           return {
             connectAsync: async (...args: any[]) => {
               mockConnectAsync(...args);
+              return {};
             },
           };
         },

--- a/packages/wagmi/src/wagmi-provider/__tests__/connect-with-universal-wallet.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/connect-with-universal-wallet.test.tsx
@@ -58,6 +58,7 @@ vi.mock('wagmi', () => {
         connectAsync: (options: any) => {
           connectAsync(options);
           event.emit('connectChanged', true);
+          return {};
         },
       };
     },

--- a/packages/wagmi/src/wagmi-provider/__tests__/ens.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/ens.test.tsx
@@ -30,7 +30,9 @@ vi.mock('wagmi', () => {
     useConnect: () => {
       return {
         connectors: [],
-        connectAsync: () => {},
+        connectAsync: async () => {
+          return {};
+        },
       };
     },
     useDisconnect: () => {

--- a/packages/wagmi/src/wagmi-provider/__tests__/nft.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/nft.test.tsx
@@ -31,7 +31,9 @@ vi.mock('wagmi', () => {
     useConnect: () => {
       return {
         connectors: [],
-        connectAsync: () => {},
+        connectAsync: async () => {
+          return {};
+        },
       };
     },
     useDisconnect: () => {

--- a/packages/wagmi/src/wagmi-provider/__tests__/unconnected.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/unconnected.test.tsx
@@ -31,7 +31,9 @@ vi.mock('wagmi', () => {
     useConnect: () => {
       return {
         connectors: [mockConnector],
-        connectAsync: () => {},
+        connectAsync: async () => {
+          return {};
+        },
       };
     },
     useDisconnect: () => {

--- a/packages/wagmi/src/wagmi-provider/config-provider.tsx
+++ b/packages/wagmi/src/wagmi-provider/config-provider.tsx
@@ -209,10 +209,13 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
         if (!connector) {
           throw new Error(`Can not find connector for ${wallet?.name}`);
         }
-        await connectAsync({
+        const { accounts } = await connectAsync({
           connector,
           chainId: currentChain?.id,
         });
+        return {
+          address: accounts?.[0],
+        };
       }}
       disconnect={async () => {
         // await disconnectAsync();

--- a/packages/web3/src/connector/__tests__/basic.test.tsx
+++ b/packages/web3/src/connector/__tests__/basic.test.tsx
@@ -136,6 +136,9 @@ describe('Connector', () => {
             setAccount({
               address: '0x1234567890',
             });
+            return {
+              address: '0x1234567890',
+            };
           }}
           disconnect={async () => {
             setAccount(undefined);
@@ -161,7 +164,7 @@ describe('Connector', () => {
 
     await vi.waitFor(() => {
       expect(onConnectCallTest).toBeCalled();
-      expect(onConnected).toBeCalled();
+      expect(onConnected).toBeCalledWith({ address: '0x1234567890' });
     });
 
     fireEvent.click(baseElement.querySelector('.ant-modal-close')!);

--- a/packages/web3/src/connector/__tests__/basic.test.tsx
+++ b/packages/web3/src/connector/__tests__/basic.test.tsx
@@ -145,8 +145,8 @@ describe('Connector', () => {
           }}
           onDisconnected={onDisconnected}
           onDisconnect={onDisconnect}
-          onConnected={(account) => {
-            onConnected(account);
+          onConnected={(a) => {
+            onConnected(a);
           }}
         >
           <CustomButton>children</CustomButton>
@@ -229,8 +229,8 @@ describe('Connector', () => {
           }}
           onDisconnected={onDisconnected}
           onDisconnect={onDisconnect}
-          onConnected={(account) => {
-            onConnected(account);
+          onConnected={(a) => {
+            onConnected(a);
           }}
         >
           <CustomButton>children</CustomButton>

--- a/packages/web3/src/connector/__tests__/basic.test.tsx
+++ b/packages/web3/src/connector/__tests__/basic.test.tsx
@@ -116,7 +116,7 @@ describe('Connector', () => {
         </Button>
       );
     };
-    const onConnected = vi.fn();
+    const onConnected = vi.fn((account) => account);
 
     const App = () => {
       const [account, setAccount] = React.useState<Account | undefined>();
@@ -146,7 +146,7 @@ describe('Connector', () => {
           onDisconnected={onDisconnected}
           onDisconnect={onDisconnect}
           onConnected={() => {
-            onConnected();
+            onConnected({ address: '0x1234567890' });
           }}
         >
           <CustomButton>children</CustomButton>

--- a/packages/web3/src/connector/connector.tsx
+++ b/packages/web3/src/connector/connector.tsx
@@ -38,8 +38,8 @@ export const Connector: React.FC<ConnectorProps> = (props) => {
     onConnect?.();
     try {
       setConnecting(true);
-      await connect?.(wallet, options);
-      onConnected?.();
+      const connectedAccount = await connect?.(wallet, options);
+      onConnected?.(connectedAccount ? connectedAccount : undefined);
       setOpen(false);
     } catch (e: any) {
       if (typeof onConnectError === 'function') {

--- a/packages/web3/src/connector/index.md
+++ b/packages/web3/src/connector/index.md
@@ -29,11 +29,11 @@ In addition, `Connector` is usually used with [adapter](../../guide/adapter). Th
 | --- | --- | --- | --- | --- |
 | children | Connection control, typically a `ConnectButton` | `React.ReactNode` | - | - |
 | modalProps | Properties passed through to `ConnectModal`. | `ModalProps` | - | - |
-| onConnect | Callback when triggering the connection. | `() => Promise<void>` | - | - |
-| onDisconnect | Callback when triggering the disconnection. | `() => Promise<void>` | - | - |
-| onConnected | Callback when the connection is successful. | `() => Promise<void>` | - | - |
-| onDisconnected | Callback when the connection is disconnected. | `() => Promise<void>` | - | - |
-| onChainSwitched | Callback when switching networks. | `(chain: Chain) => Promise<void>` | - | - |
+| onConnect | Callback when triggering the connection. | `() => void` | - | - |
+| onDisconnect | Callback when triggering the disconnection. | `() => void` | - | - |
+| onConnected | Callback when the connection is successful. The availability of `account` depends on the adapter implementation. | `(account?: Account) => void` | - | - |
+| onDisconnected | Callback when the connection is disconnected. | `() => void` | - | - |
+| onChainSwitched | Callback when switching networks. | `(chain: Chain) => void` | - | - |
 | availableWallets | Available aallet list | `Wallet[]` | - | - |
 | account | Current connected account | `Account` | - | - |
 | availableChains | List of available chains | `Chain[]` | - | - |

--- a/packages/web3/src/connector/index.zh-CN.md
+++ b/packages/web3/src/connector/index.zh-CN.md
@@ -30,11 +30,11 @@ group: UI 组件
 | --- | --- | --- | --- | --- |
 | children | 连接控件，通常是 `ConnectButton` | `React.ReactNode` | - | - |
 | modalProps | 透传给 `ConnectModal` 的属性 | `ModalProps` | - | - |
-| onConnect | 触发连接时的回调 | `() => Promise<void>` | - | - |
-| onDisconnect | 触发断开连接时的回调 | `() => Promise<void>` | - | - |
-| onConnected | 连接成功时的回调 | `() => Promise<void>` | - | - |
-| onDisconnected | 断开连接时的回调 | `() => Promise<void>` | - | - |
-| onChainSwitched | 切换网络时的回调 | `(chain: Chain) => Promise<void>` | - | - |
+| onConnect | 触发连接时的回调 | `() => void` | - | - |
+| onDisconnect | 触发断开连接时的回调 | `() => void` | - | - |
+| onConnected | 连接成功时的回调，`account` 是否可用取决于适配器实现 | `(account?: Account) => void` | - | - |
+| onDisconnected | 断开连接时的回调 | `() => void` | - | - |
+| onChainSwitched | 切换网络时的回调 | `(chain: Chain) => void` | - | - |
 | availableWallets | 钱包列表 | `Wallet[]` | - | - |
 | account | 当前连接账号 | `Account[]` | - | - |
 | availableChains | 可以连接的链列表 | `Chain[]` | - | - |

--- a/packages/web3/src/connector/interface.ts
+++ b/packages/web3/src/connector/interface.ts
@@ -6,7 +6,7 @@ export interface ConnectorProps {
   modalProps?: ConnectModalProps;
   onConnect?: () => void;
   onDisconnect?: () => void;
-  onConnected?: () => void;
+  onConnected?: (account?: Account) => void;
   onDisconnected?: () => void;
   onChainSwitched?: (chain?: Chain) => void;
   onConnectError?: (error?: Error) => void;
@@ -17,7 +17,7 @@ export interface ConnectorProps {
   availableChains?: Chain[];
   availableWallets?: Wallet[];
 
-  connect?: (wallet?: Wallet) => Promise<void>;
+  connect?: (wallet?: Wallet) => Promise<void | Account>;
   disconnect?: () => Promise<void>;
   switchChain?: (chain: Chain) => Promise<void>;
 }

--- a/packages/web3/src/ethereum/demos/eip6963.tsx
+++ b/packages/web3/src/ethereum/demos/eip6963.tsx
@@ -1,5 +1,6 @@
 import { ConnectButton, Connector } from '@ant-design/web3';
 import { MetaMask, WagmiWeb3ConfigProvider } from '@ant-design/web3-wagmi';
+import { message } from 'antd';
 import { createConfig, http } from 'wagmi';
 import { mainnet } from 'wagmi/chains';
 
@@ -19,7 +20,11 @@ const App: React.FC = () => {
       }}
       wallets={[MetaMask()]}
     >
-      <Connector>
+      <Connector
+        onConnected={(account) => {
+          message.success(`Connected to ${account?.address}`);
+        }}
+      >
         <ConnectButton />
       </Connector>
     </WagmiWeb3ConfigProvider>

--- a/packages/web3/src/ethereum/demos/eip6963.tsx
+++ b/packages/web3/src/ethereum/demos/eip6963.tsx
@@ -12,6 +12,7 @@ const config = createConfig({
 });
 
 const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   return (
     <WagmiWeb3ConfigProvider
       config={config}
@@ -22,11 +23,12 @@ const App: React.FC = () => {
     >
       <Connector
         onConnected={(account) => {
-          message.success(`Connected to ${account?.address}`);
+          messageApi.success(`Connected to ${account?.address}`);
         }}
       >
         <ConnectButton />
       </Connector>
+      {contextHolder}
     </WagmiWeb3ConfigProvider>
   );
 };

--- a/packages/web3/src/types/index.md
+++ b/packages/web3/src/types/index.md
@@ -87,7 +87,7 @@ This is an enum type that contains the IDs of some commonly used chains. Its val
 | chain | Current chain | [Chain](#chain) | - | - |
 | availableChains | List of available chains | [Chain](#chain)\[] | - | - |
 | availableWallets | List of available wallets | [Wallet](#wallet)\[] | - | - |
-| connect | Connect to the wallet | `(wallet: Wallet, options?: ConnectOptions) => Promise<void>` | - | - |
+| connect | Connect to the wallet | `(wallet: Wallet, options?: ConnectOptions) => Promise<void \| Account>` | - | - |
 | disconnect | Disconnect from the chain | `() => Promise<void>` | - | - |
 | switchChain | Switch to another chain | `(chainId: ChainIds) => Promise<void>` | - | - |
 | getNFTMetadata | Get the metadata of the NFT | `(contractAddress: string, tokenId?: string) => Promise<NFTMetadata>` | - | - |

--- a/packages/web3/src/types/index.zh-CN.md
+++ b/packages/web3/src/types/index.zh-CN.md
@@ -88,7 +88,7 @@ order: 3
 | chain | 当前链 | [Chain](#chain) | - | - |
 | availableChains | 可以连接的链列表 | [Chain](#chain)[] | - | - |
 | availableWallets | 可用的钱包列表 | [Wallet](#wallet)[] | - | - |
-| connect | 连接钱包 | `(wallet: Wallet, options?: ConnectOptions) => Promise<void>` | - | - |
+| connect | 连接钱包 | `(wallet: Wallet, options?: ConnectOptions) => Promise<void \| Account>` | - | - |
 | disconnect | 断开钱包连接 | `() => Promise<void>` | - | - |
 | switchChain | 切换链 | `(chain: Chain) => Promise<void>` | - | - |
 | getNFTMetadata | 获取 NFT 的元数据 | `(params: { address: string; tokenId?: bigint \| number }) => Promise<NFTMetadata>` | - | - |


### PR DESCRIPTION

## 💡 Background and solution

`onConnected` 方法参数中没有连接的账号信息，在一些需求中会有需要，比如连接成功后请求地址相关信息。

该  PR 新增相关参数。
