### PR TITLE
fix: circle bg image in home page

### DIFF
--- a/.dumi/theme/builtins/HomePage/components/Theme/index.module.less
+++ b/.dumi/theme/builtins/HomePage/components/Theme/index.module.less
@@ -26,8 +26,9 @@
     left: 80px;
     bottom: 60px;
     width: 486px;
-    height: 486px;
-    background-image: url(https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*vhNURbKgnA0AAAAAAAAAAAAADlrGAQ/original);
+    height: 386px;
+    background-image: url(https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*Wcc_S5HOjE8AAAAAAAAAAAAADlrGAQ/original);
+    background-repeat: no-repeat;
     background-size: contain;
   }
 


### PR DESCRIPTION

## 💡 Background and solution

之前的图有点问题，修改前：

<img width="683" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/1061968/4792e0bd-ce10-4af6-ba77-69241ddc8824">

修改后：

<img width="665" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/1061968/4cdc7f07-b5ce-445e-9f8c-2e590cbd7cdb">



## 🔗 Related issue link

