### PR TITLE
fix: wallet list scroll cover style in dark mode

### DIFF
--- a/.changeset/blue-rats-sort.md
+++ b/.changeset/blue-rats-sort.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix: wallet list scroll cover style in dark mode

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -220,9 +220,11 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
               width: token.walletListWidth - token.paddingMD * 2,
               left: token.paddingMD,
               height: token.controlHeightLG,
-              backgroundImage: `linear-gradient(to bottom, ${new TinyColor(token.colorBgBase)
+              backgroundImage: `linear-gradient(to bottom, ${new TinyColor(token.colorBgContainer)
                 .setAlpha(0)
-                .toRgbString()}, ${new TinyColor(token.colorBgBase).setAlpha(1).toRgbString()})`,
+                .toRgbString()}, ${new TinyColor(token.colorBgContainer)
+                .setAlpha(1)
+                .toRgbString()})`,
               pointerEvents: 'none',
             },
           },


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

修复前：

<img width="989" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/1061968/31311fb5-6a06-478b-af80-5b66ba2c298b">

修复后

<img width="1091" alt="image" src="https://github.com/ant-design/ant-design-web3/assets/1061968/fbfe8826-22c7-4b72-abeb-201ad1f8e58b">


## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
