### PR TITLE
docs(types): translate table titles in zh doc

### DIFF
--- a/packages/web3/src/types/index.zh-CN.md
+++ b/packages/web3/src/types/index.zh-CN.md
@@ -32,7 +32,7 @@ order: 3
 
 ### ChainBrowser
 
-| Property | Description | Type | Default | Version |
+| 属性 | 描述 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | icon | 链浏览器图标 | `React.ReactNode` | - | - |
 | getBrowserLink | 从区块链浏览器获取地址或交易链接方法 | `(address: string, type: 'address' \| 'transaction') => string` | - | - |
@@ -114,10 +114,10 @@ order: 3
 
 ### TokenChain
 
-| Property | Description          | Type            | Default | Version |
-| -------- | -------------------- | --------------- | ------- | ------- |
-| chain    | 链信息               | [Chain](#chain) | -       | -       |
-| contract | 代币在该链的合约地址 | `string`        | -       |
+| 属性     | 描述                 | 类型            | 默认值 | 版本 |
+| -------- | -------------------- | --------------- | ------ | ---- |
+| chain    | 链信息               | [Chain](#chain) | -      | -    |
+| contract | 代币在该链的合约地址 | `string`        | -      |
 
 ## Locale
 


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution
现在zh文档中， 中英文table title并存，统一为中文

before：
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/11fbddbf-8d0b-4711-bab9-8ce045a7b9a8)

after：
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/a301eb66-d2ea-47fd-8127-a3e6c74c6775)

<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

