### PR TITLE
docs: remove unuseful ThemeToken about CryptoInput component

### DIFF
--- a/.changeset/green-olives-deliver.md
+++ b/.changeset/green-olives-deliver.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+docs: remove unuseful ThemeToken about CryptoInput component

--- a/.changeset/green-olives-deliver.md
+++ b/.changeset/green-olives-deliver.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-docs: remove unuseful ThemeToken about CryptoInput component

--- a/packages/web3/src/crypto-input/index.md
+++ b/packages/web3/src/crypto-input/index.md
@@ -60,7 +60,3 @@ group:
 | amount   | user had token amount              | `bigint`           | -       | -       |
 | price    | token price                        | `string \| number` | -       | -       |
 | unit     | token price display unit, like "$" | `bigint`           | -       | -       |
-
-## Design Token
-
-[Please ref Ant Design InputNumber](https://ant-design.antgroup.com/components/input-number-cn#%E4%B8%BB%E9%A2%98%E5%8F%98%E9%87%8Fdesign-token)

--- a/packages/web3/src/crypto-input/index.zh-CN.md
+++ b/packages/web3/src/crypto-input/index.zh-CN.md
@@ -61,7 +61,3 @@ group:
 | amount | 用户拥有的代币数量       | `bigint`           | -      | -    |
 | price  | 代币的价格               | `string \| number` | -      | -    |
 | unit   | 代币价格的单位，比如 "$" | `string`           | -      | -    |
-
-## 主题变量
-
-[请参考 Ant Design InputNumber 组件](https://ant-design.antgroup.com/components/input-number-cn#%E4%B8%BB%E9%A2%98%E5%8F%98%E9%87%8Fdesign-token)


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

由于不在使用 ConfigProvider 实现样式覆盖，删除 CryptoInput 组件中无用的主体变量模块

<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
