### PR TITLE
fix: add lodash-es for @ant-design/web3

### DIFF
--- a/.changeset/lovely-horses-obey.md
+++ b/.changeset/lovely-horses-obey.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix: add lodash-es for @ant-design/web3

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -52,7 +52,8 @@
     "bs58": "^5.0.0",
     "classnames": "^2.5.1",
     "copy-to-clipboard": "^3.3.3",
-    "decimal.js": "^10.4.3"
+    "decimal.js": "^10.4.3",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@ant-design/web3-bitcoin": "workspace:*",
@@ -63,7 +64,8 @@
     "@types/react": "^18.2.78",
     "@types/react-dom": "^18.2.25",
     "father": "^4.4.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@types/lodash-es": "^4.17.12"
   },
   "peerDependencies": {
     "antd": ">=5.0.0",

--- a/packages/web3/src/crypto-input/index.tsx
+++ b/packages/web3/src/crypto-input/index.tsx
@@ -2,7 +2,7 @@ import React, { useDeferredValue } from 'react';
 import type { Token } from '@ant-design/web3-common';
 import { theme as antdTheme, Flex, InputNumber, Typography } from 'antd';
 import Decimal from 'decimal.js';
-import { isNull } from 'lodash';
+import { isNull } from 'lodash-es';
 
 import { CryptoPrice } from '../crypto-price';
 import useIntl from '../hooks/useIntl';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,6 +633,9 @@ importers:
       decimal.js:
         specifier: ^10.4.3
         version: 10.4.3
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       react:
         specifier: '>=17.0.0'
         version: 18.2.0
@@ -655,6 +658,9 @@ importers:
       '@ant-design/web3-wagmi':
         specifier: workspace:*
         version: link:../wagmi
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/react':
         specifier: ^18.2.78
         version: 18.2.78


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

添加缺少的 lodash-es 依赖

## 🔗 Related issue link

close #985 
