### PR TITLE
fix(mobile): width display overflow

### DIFF
--- a/.changeset/strong-islands-happen.md
+++ b/.changeset/strong-islands-happen.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix(connect-modal): footer-container mask width overflow

--- a/.dumi/theme/builtins/HomePage/components/ShowCase/CryptoInput.tsx
+++ b/.dumi/theme/builtins/HomePage/components/ShowCase/CryptoInput.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => {
     <div className={styles.cardBg}>
       <span className={styles.title}>Crypto Input</span>
       <Card>
-        <Flex vertical align="center" style={{ width: 400 }} gap={16}>
+        <Flex vertical align="center" gap={16}>
           <CryptoInput
             header={'Sell'}
             value={cryptoPair[0]}

--- a/.dumi/theme/builtins/HomePage/components/ShowCase/CryptoInput.tsx
+++ b/.dumi/theme/builtins/HomePage/components/ShowCase/CryptoInput.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => {
     <div className={styles.cardBg}>
       <span className={styles.title}>Crypto Input</span>
       <Card>
-        <Flex vertical align="center" gap={16}>
+        <Flex vertical align="center" style={{ maxWidth: 400 }} gap={16}>
           <CryptoInput
             header={'Sell'}
             value={cryptoPair[0]}

--- a/.dumi/theme/builtins/HomePage/components/ShowCase/PayPanel.tsx
+++ b/.dumi/theme/builtins/HomePage/components/ShowCase/PayPanel.tsx
@@ -20,7 +20,7 @@ const GasRender: React.FC = () => {
   return (
     <div className={styles.cardBg}>
       <span className={styles.title}>Pay Panel</span>
-      <Card style={{ width: 400 }}>
+      <Card>
         <PayPanel
           target={{
             [Mainnet.id]: '0x35ceCD3d51Fe9E5AD14ea001475668C5A5e5ea76',

--- a/.dumi/theme/builtins/HomePage/components/ShowCase/PayPanel.tsx
+++ b/.dumi/theme/builtins/HomePage/components/ShowCase/PayPanel.tsx
@@ -20,7 +20,7 @@ const GasRender: React.FC = () => {
   return (
     <div className={styles.cardBg}>
       <span className={styles.title}>Pay Panel</span>
-      <Card>
+      <Card style={{ maxWidth: 400 }}>
         <PayPanel
           target={{
             [Mainnet.id]: '0x35ceCD3d51Fe9E5AD14ea001475668C5A5e5ea76',

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -217,7 +217,7 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
               content: '""',
               position: 'absolute',
               bottom: '100%',
-              width: token.walletListWidth - token.paddingMD * 2,
+              width: '98%',
               left: '50%',
               transform: 'translateX(-50%)',
               height: token.controlHeightLG,

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -219,7 +219,7 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
               bottom: '100%',
               width: token.walletListWidth - token.paddingMD * 2,
               left: '50%',
-              transform: 'translate(-50%)',
+              transform: 'translateX(-50%)',
               height: token.controlHeightLG,
               backgroundImage: `linear-gradient(to bottom, ${new TinyColor(token.colorBgContainer)
                 .setAlpha(0)

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -218,7 +218,8 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
               position: 'absolute',
               bottom: '100%',
               width: token.walletListWidth - token.paddingMD * 2,
-              left: token.paddingMD,
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
               height: token.controlHeightLG,
               backgroundImage: `linear-gradient(to bottom, ${new TinyColor(token.colorBgContainer)
                 .setAlpha(0)

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -219,7 +219,7 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
               bottom: '100%',
               width: token.walletListWidth - token.paddingMD * 2,
               left: '50%',
-              transform: 'translate(-50%, -50%)',
+              transform: 'translate(-50%)',
               height: token.controlHeightLG,
               backgroundImage: `linear-gradient(to bottom, ${new TinyColor(token.colorBgContainer)
                 .setAlpha(0)

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -217,7 +217,7 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
               content: '""',
               position: 'absolute',
               bottom: '100%',
-              width: '98%',
+              width: 'calc(100% - 20px)',
               left: '50%',
               transform: 'translateX(-50%)',
               height: token.controlHeightLG,

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -217,7 +217,7 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
               content: '""',
               position: 'absolute',
               bottom: '100%',
-              width: 'calc(100% - 20px)',
+              width: `calc(100% - ${token.paddingMD * 2}px)`,
               left: '50%',
               transform: 'translateX(-50%)',
               height: token.controlHeightLG,


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution
1. 移动端宽度不到400px, 去掉card中配置的width
2. connect-modal footer mask 被left 挤出去了，既然用了绝对定位可以用`transform: 'translateX(-50%)'` 来水平居中。
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/f51cc851-1d89-4b10-9fe6-c6346d4ec71c)

<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

## 🔗 Related issue link
#989 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
