### PR TITLE
type: import React type

### DIFF
--- a/.dumi/theme/builtins/HomePage/components/ShowCase/CryptoInput.tsx
+++ b/.dumi/theme/builtins/HomePage/components/ShowCase/CryptoInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { SwapOutlined } from '@ant-design/icons';
 import { CryptoInput, type CryptoInputProps, type Token } from '@ant-design/web3';
 import { ETH, USDT } from '@ant-design/web3-assets/tokens';

--- a/docs/meetup2024/mint.tsx
+++ b/docs/meetup2024/mint.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useAccount } from '@ant-design/web3';
 import { Button, message } from 'antd';
 import { useReadContract, useWriteContract } from 'wagmi';
 
 const contractAddress = '0x8fab440bf0279695100c944e498c64fe612b2338';
 
-const Mint = () => {
+const Mint: React.FC = () => {
   const { account } = useAccount();
   const [mintSuccess, setMintSuccess] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/packages/web3/src/bitcoin/demos/get-inscriptions.tsx
+++ b/packages/web3/src/bitcoin/demos/get-inscriptions.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { ConnectButton, Connector, NFTImage } from '@ant-design/web3';
 import {
   BitcoinWeb3ConfigProvider,

--- a/packages/web3/src/crypto-input/demos/basic.tsx
+++ b/packages/web3/src/crypto-input/demos/basic.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { CryptoInput, type CryptoInputProps, type Token } from '@ant-design/web3';
 import { ETH, USDT } from '@ant-design/web3-assets/tokens';
 

--- a/packages/web3/src/crypto-input/demos/customFooter.tsx
+++ b/packages/web3/src/crypto-input/demos/customFooter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import type { CryptoInputProps } from '@ant-design/web3';
 import { CryptoInput } from '@ant-design/web3';
 import { ETH, USDT } from '@ant-design/web3-assets/tokens';

--- a/packages/web3/src/crypto-input/demos/customHeader.tsx
+++ b/packages/web3/src/crypto-input/demos/customHeader.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { CryptoInput, type CryptoInputProps } from '@ant-design/web3';
 import { ETH, USDT } from '@ant-design/web3-assets/tokens';
 

--- a/packages/web3/src/crypto-input/demos/noFooter.tsx
+++ b/packages/web3/src/crypto-input/demos/noFooter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { CryptoInput, type CryptoInputProps } from '@ant-design/web3';
 import { ETH, USDT } from '@ant-design/web3-assets/tokens';
 

--- a/packages/web3/src/crypto-input/demos/sizeChange.tsx
+++ b/packages/web3/src/crypto-input/demos/sizeChange.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { CryptoInput, type CryptoInputProps, type Token } from '@ant-design/web3';
 import { ETH, USDT } from '@ant-design/web3-assets/tokens';
 import { Radio } from 'antd';

--- a/packages/web3/src/crypto-input/demos/swapMode.tsx
+++ b/packages/web3/src/crypto-input/demos/swapMode.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { SwapOutlined } from '@ant-design/icons';
 import { CryptoInput, type CryptoInputProps, type Token } from '@ant-design/web3';
 import { ETH, USDT } from '@ant-design/web3-assets/tokens';

--- a/packages/web3/src/pay-panel/demos/modal.tsx
+++ b/packages/web3/src/pay-panel/demos/modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { PayPanel } from '@ant-design/web3';
 import {
   BSC,

--- a/packages/web3/src/token-select/demos/basic.tsx
+++ b/packages/web3/src/token-select/demos/basic.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { TokenSelect, type Token } from '@ant-design/web3';
 import { ETH, USDT } from '@ant-design/web3-assets/tokens';
 

--- a/packages/web3/src/token-select/demos/withSearch.tsx
+++ b/packages/web3/src/token-select/demos/withSearch.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { TokenSelect, type Token } from '@ant-design/web3';
 import { ETH, USDT } from '@ant-design/web3-assets/tokens';
 


### PR DESCRIPTION
 函数组件都使用了 `React: FC`, 但很多未在顶部导出，用户如果复制demo的时候可能会提示错误。

我直接统一都加上了
 

![image](https://github.com/ant-design/ant-design-web3/assets/117748716/827b8e39-0063-4ab6-b7da-729b2b13a65f)
