### PR TITLE
fix: improve crypto-input

### DIFF
--- a/.changeset/few-tools-perform.md
+++ b/.changeset/few-tools-perform.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix: improve crypto-input

--- a/packages/web3/src/crypto-input/__tests__/index.test.tsx
+++ b/packages/web3/src/crypto-input/__tests__/index.test.tsx
@@ -203,24 +203,30 @@ describe('CryptoInput component', () => {
       target: { value: '10.012345678' },
     });
 
-    expect(baseElement.querySelector('.total-price')?.textContent).toBe('$ 38993.78110716846');
-    expect(baseElement.querySelector('.token-balance')?.textContent).includes('100');
+    expect(baseElement.querySelector('.web3-crypto-input-total-price')?.textContent).toBe(
+      '$ 38993.78110716846',
+    );
+    expect(baseElement.querySelector('.web3-crypto-input-token-balance')?.textContent).includes(
+      '100',
+    );
 
     // change token amount to max
-    fireEvent.click(baseElement.querySelector('.max-button') as Element);
+    fireEvent.click(baseElement.querySelector('.web3-crypto-input-max-button') as Element);
 
     expect(baseElement.querySelector('.ant-input-number-input')?.getAttribute('value')).toBe('100');
-    expect(baseElement.querySelector('.total-price')?.textContent).toBe('$ 389457');
+    expect(baseElement.querySelector('.web3-crypto-input-total-price')?.textContent).toBe(
+      '$ 389457',
+    );
 
     // set token amount to null
     fireEvent.change(baseElement.querySelector('.ant-input-number-input') as Element, {
       target: { value: null },
     });
 
-    expect(baseElement.querySelector('.total-price')?.textContent).toBe('-');
+    expect(baseElement.querySelector('.web3-crypto-input-total-price')?.textContent).toBe('-');
 
     // change token balance to undefined
     rerender(<TestComponent balance={undefined} />);
-    expect(baseElement.querySelector('.total-price')?.textContent).toBe('-');
+    expect(baseElement.querySelector('.web3-crypto-input-total-price')?.textContent).toBe('-');
   });
 });

--- a/packages/web3/src/crypto-input/index.tsx
+++ b/packages/web3/src/crypto-input/index.tsx
@@ -150,6 +150,7 @@ export const CryptoInput: React.FC<CryptoInputProps> = ({
                 {!!balance?.amount && (
                   <a
                     className={getClsName('max-button')}
+                    role="button"
                     onClick={() => {
                       onChange?.({
                         ...value,

--- a/packages/web3/src/crypto-input/index.tsx
+++ b/packages/web3/src/crypto-input/index.tsx
@@ -1,6 +1,6 @@
 import React, { useDeferredValue } from 'react';
 import type { Token } from '@ant-design/web3-common';
-import { theme as antdTheme, Flex, InputNumber, Typography } from 'antd';
+import { Flex, InputNumber, Typography } from 'antd';
 import Decimal from 'decimal.js';
 import { isNull } from 'lodash-es';
 
@@ -58,10 +58,6 @@ export const CryptoInput: React.FC<CryptoInputProps> = ({
   ...selectProps
 }) => {
   const { messages } = useIntl('CryptoInput');
-
-  const {
-    token: { InputNumber: CUSTOM_TOKEN },
-  } = antdTheme.useToken();
 
   const { token, inputString } = value || {};
 
@@ -135,11 +131,14 @@ export const CryptoInput: React.FC<CryptoInputProps> = ({
       {footer !== false && (
         <div className={getClsName('footer')}>
           {footer || (
-            <Flex className="default-footer" justify="space-between">
-              <Typography.Text ellipsis={{ tooltip: tokenTotalPrice }} className="total-price">
+            <Flex className={getClsName('total-default-footer')} justify="space-between">
+              <Typography.Text
+                ellipsis={{ tooltip: tokenTotalPrice }}
+                className={getClsName('total-price')}
+              >
                 {tokenTotalPrice || '-'}
               </Typography.Text>
-              <span className="token-balance">
+              <span className={getClsName('token-balance')}>
                 {!!token && (
                   <CryptoPrice
                     {...token}
@@ -150,7 +149,7 @@ export const CryptoInput: React.FC<CryptoInputProps> = ({
                 )}
                 {!!balance?.amount && (
                   <a
-                    className="max-button"
+                    className={getClsName('max-button')}
                     onClick={() => {
                       onChange?.({
                         ...value,


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution


1. remove unused antdTheme.useToken

2. improve classname，不带prefixCls的易于用户的自定义classname产生样式冲突