### PR TITLE
fix: ConnectModal style bug in dark theme

### DIFF
--- a/.changeset/chilled-birds-help.md
+++ b/.changeset/chilled-birds-help.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix: ConnectModal style bug in dark theme

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "repository": "https://github.com/ant-design/ant-design-web3.git",
   "dependencies": {
-    "@ant-design/cssinjs": "^1.20.0",
+    "@ant-design/cssinjs": "^1.21.0",
     "@ant-design/icons": "^5.3.7",
     "@ant-design/web3": "workspace:*",
     "@ant-design/web3-assets": "workspace:*",
@@ -112,9 +112,9 @@
     "dumi-theme-antd-web3": "0.4.2",
     "ethers": "^6.13.1",
     "github-contributors-lists": "^1.0.3",
-    "react": "^18.2.0",
+    "react": "18.2.0",
     "react-copy-to-clipboard": "^5.1.0",
-    "react-dom": "^18.2.0",
+    "react-dom": "18.2.0",
     "viem": "^2.16.5",
     "wagmi": "^2.10.5"
   }

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -48,7 +48,7 @@
     "@ant-design/web3-icons": "workspace:*",
     "@ctrl/tinycolor": "^4.1.0",
     "@inline-svg-unique-id/react": "^1.2.3",
-    "antd": "^5.17.3",
+    "antd": "^5.18.3",
     "bs58": "^5.0.0",
     "classnames": "^2.5.1",
     "copy-to-clipboard": "^3.3.3",

--- a/packages/web3/src/address/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/web3/src/address/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`Address > display address with default format 1`] = `
 <div
-  class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small ant-web3-address css-dev-only-do-not-override-17seli4"
+  class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small ant-web3-address css-dev-only-do-not-override-m4timi"
 >
   <div
     class="ant-space-item"
   >
     <span
-      class="ant-typography css-dev-only-do-not-override-17seli4"
+      class="ant-typography css-dev-only-do-not-override-m4timi"
     >
       <span>
         0x 21CD f097 4d53 a6e9 6eF0 5d7B 324a 9803 735f Fd3B

--- a/packages/web3/src/connect-button/__tests__/__snapshots__/profile-modal.test.tsx.snap
+++ b/packages/web3/src/connect-button/__tests__/__snapshots__/profile-modal.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ProfileModal > match snapshot 1`] = `
   <div />
   <div>
     <div
-      class="ant-modal-root css-dev-only-do-not-override-17seli4"
+      class="ant-modal-root css-dev-only-do-not-override-m4timi"
     >
       <div
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
@@ -16,7 +16,7 @@ exports[`ProfileModal > match snapshot 1`] = `
       >
         <div
           aria-modal="true"
-          class="ant-modal css-dev-only-do-not-override-17seli4 hashId ant-web3-connect-button-profile-modal ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
+          class="ant-modal css-dev-only-do-not-override-m4timi hashId ant-web3-connect-button-profile-modal ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
           role="dialog"
           style="width: 280px;"
         >
@@ -67,13 +67,13 @@ exports[`ProfileModal > match snapshot 1`] = `
                 style="text-align: center;"
               >
                 <div
-                  class="ant-space css-dev-only-do-not-override-17seli4 ant-space-vertical ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                  class="ant-space css-dev-only-do-not-override-m4timi ant-space-vertical ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                 >
                   <div
                     class="ant-space-item"
                   >
                     <span
-                      class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-17seli4"
+                      class="ant-avatar ant-avatar-circle ant-avatar-image css-dev-only-do-not-override-m4timi"
                     >
                       <img
                         src="https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*9jfLS41kn00AAAAAAAAAAAAADlrGAQ/original"
@@ -93,13 +93,13 @@ exports[`ProfileModal > match snapshot 1`] = `
                     class="ant-space-item"
                   >
                     <div
-                      class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small ant-web3-address css-dev-only-do-not-override-17seli4"
+                      class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small ant-web3-address css-dev-only-do-not-override-m4timi"
                     >
                       <div
                         class="ant-space-item"
                       >
                         <span
-                          class="ant-typography css-dev-only-do-not-override-17seli4"
+                          class="ant-typography css-dev-only-do-not-override-m4timi"
                         >
                           <span>
                             0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B
@@ -117,7 +117,7 @@ exports[`ProfileModal > match snapshot 1`] = `
                   class="ant-web3-connect-button-profile-modal-footer hashId"
                 >
                   <button
-                    class="ant-btn css-dev-only-do-not-override-17seli4 ant-btn-default"
+                    class="ant-btn css-dev-only-do-not-override-m4timi ant-btn-default"
                     type="button"
                   >
                     <span>
@@ -125,7 +125,7 @@ exports[`ProfileModal > match snapshot 1`] = `
                     </span>
                   </button>
                   <button
-                    class="ant-btn css-dev-only-do-not-override-17seli4 ant-btn-default"
+                    class="ant-btn css-dev-only-do-not-override-m4timi ant-btn-default"
                     type="button"
                   >
                     <span>

--- a/packages/web3/src/connect-button/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/packages/web3/src/connect-button/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ConnectButton > should display formatted by custom formatter when pass 
 <body>
   <div>
     <button
-      class="ant-btn css-dev-only-do-not-override-17seli4 ant-btn-default ant-web3-connect-button css-dev-only-do-not-override-17seli4 ant-tooltip-open"
+      class="ant-btn css-dev-only-do-not-override-m4timi ant-btn-default ant-web3-connect-button css-dev-only-do-not-override-m4timi ant-tooltip-open"
       type="button"
     >
       <div
@@ -17,13 +17,13 @@ exports[`ConnectButton > should display formatted by custom formatter when pass 
             class="ant-web3-connect-button-text"
           >
             <div
-              class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small ant-web3-address css-dev-only-do-not-override-17seli4"
+              class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small ant-web3-address css-dev-only-do-not-override-m4timi"
             >
               <div
                 class="ant-space-item"
               >
                 <span
-                  class="ant-typography css-dev-only-do-not-override-17seli4"
+                  class="ant-typography css-dev-only-do-not-override-m4timi"
                 >
                   <span>
                     0x3ea2...7c18
@@ -38,7 +38,7 @@ exports[`ConnectButton > should display formatted by custom formatter when pass 
   </div>
   <div>
     <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-web3-connect-button-tooltip css-dev-only-do-not-override-17seli4 css-dev-only-do-not-override-17seli4 ant-tooltip-placement-top"
+      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-web3-connect-button-tooltip css-dev-only-do-not-override-m4timi css-dev-only-do-not-override-m4timi ant-tooltip-placement-top"
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
     >
       <div

--- a/packages/web3/src/connect-modal/__tests__/__snapshots__/basic.test.tsx.snap
+++ b/packages/web3/src/connect-modal/__tests__/__snapshots__/basic.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ConnectModal with guide > panel route change 1`] = `
   <div />
   <div>
     <div
-      class="ant-modal-root css-dev-only-do-not-override-17seli4 ant-web3-connect-modal-root"
+      class="ant-modal-root css-dev-only-do-not-override-m4timi ant-web3-connect-modal-root"
     >
       <div
         class="ant-modal-mask ant-fade-appear ant-fade-appear-active ant-fade"
@@ -16,7 +16,7 @@ exports[`ConnectModal with guide > panel route change 1`] = `
       >
         <div
           aria-modal="true"
-          class="ant-modal css-dev-only-do-not-override-17seli4 ant-web3-connect-modal css-dev-only-do-not-override-17seli4 ant-zoom-appear ant-zoom-appear-active ant-zoom"
+          class="ant-modal css-dev-only-do-not-override-m4timi ant-web3-connect-modal css-dev-only-do-not-override-m4timi ant-zoom-appear ant-zoom-appear-active ant-zoom"
           role="dialog"
           style="width: 797px;"
         >
@@ -66,7 +66,7 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                 class="ant-modal-body"
               >
                 <div
-                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-17seli4"
+                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-m4timi"
                 >
                   <div
                     class="ant-web3-connect-modal-list-panel"
@@ -101,10 +101,10 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -124,13 +124,13 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=0"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -149,13 +149,13 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=3"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet3
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -180,10 +180,10 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -203,13 +203,13 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=1"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet2
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -227,13 +227,13 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet4
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -251,13 +251,13 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet5
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -275,13 +275,13 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -299,13 +299,13 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -373,7 +373,7 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                         class="ant-web3-connect-modal-qr-code-box"
                       >
                         <div
-                          class="ant-qrcode ant-web3-connect-modal-qr-code css-dev-only-do-not-override-17seli4"
+                          class="ant-qrcode ant-web3-connect-modal-qr-code css-dev-only-do-not-override-m4timi"
                           style="background-color: transparent; width: 346px; height: 346px;"
                         >
                           <svg
@@ -401,7 +401,7 @@ exports[`ConnectModal with guide > panel route change 1`] = `
                           target="_blank"
                         >
                           <div
-                            class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                            class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                           >
                             <div
                               class="ant-space-item"
@@ -468,7 +468,7 @@ exports[`ConnectModal with guide > panel route change 2`] = `
   <div />
   <div>
     <div
-      class="ant-modal-root css-dev-only-do-not-override-17seli4 ant-web3-connect-modal-root"
+      class="ant-modal-root css-dev-only-do-not-override-m4timi ant-web3-connect-modal-root"
     >
       <div
         class="ant-modal-mask ant-fade-appear ant-fade-appear-active ant-fade"
@@ -479,7 +479,7 @@ exports[`ConnectModal with guide > panel route change 2`] = `
       >
         <div
           aria-modal="true"
-          class="ant-modal css-dev-only-do-not-override-17seli4 ant-web3-connect-modal css-dev-only-do-not-override-17seli4 ant-zoom-appear ant-zoom-appear-active ant-zoom"
+          class="ant-modal css-dev-only-do-not-override-m4timi ant-web3-connect-modal css-dev-only-do-not-override-m4timi ant-zoom-appear ant-zoom-appear-active ant-zoom"
           role="dialog"
           style="width: 797px;"
         >
@@ -529,7 +529,7 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                 class="ant-modal-body"
               >
                 <div
-                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-17seli4"
+                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-m4timi"
                 >
                   <div
                     class="ant-web3-connect-modal-list-panel"
@@ -564,10 +564,10 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -587,13 +587,13 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=0"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -612,13 +612,13 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=3"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet3
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -643,10 +643,10 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -666,13 +666,13 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=1"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet2
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -690,13 +690,13 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet4
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -714,13 +714,13 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet5
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -738,13 +738,13 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -762,13 +762,13 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -836,7 +836,7 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                         class="ant-web3-connect-modal-qr-code-box"
                       >
                         <div
-                          class="ant-qrcode ant-web3-connect-modal-qr-code css-dev-only-do-not-override-17seli4"
+                          class="ant-qrcode ant-web3-connect-modal-qr-code css-dev-only-do-not-override-m4timi"
                           style="background-color: transparent; width: 346px; height: 346px;"
                         >
                           <svg
@@ -864,7 +864,7 @@ exports[`ConnectModal with guide > panel route change 2`] = `
                           target="_blank"
                         >
                           <div
-                            class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                            class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                           >
                             <div
                               class="ant-space-item"
@@ -931,7 +931,7 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
   <div />
   <div>
     <div
-      class="ant-modal-root css-dev-only-do-not-override-17seli4 ant-web3-connect-modal-root"
+      class="ant-modal-root css-dev-only-do-not-override-m4timi ant-web3-connect-modal-root"
     >
       <div
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
@@ -942,9 +942,9 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
       >
         <div
           aria-modal="true"
-          class="ant-modal css-dev-only-do-not-override-17seli4 ant-web3-connect-modal css-dev-only-do-not-override-17seli4 ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
+          class="ant-modal css-dev-only-do-not-override-m4timi ant-web3-connect-modal css-dev-only-do-not-override-m4timi ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
           role="dialog"
-          style="width: 797px; transform-origin: 0px 0px;"
+          style="width: 797px;"
         >
           <div
             aria-hidden="true"
@@ -992,7 +992,7 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                 class="ant-modal-body"
               >
                 <div
-                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-17seli4"
+                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-m4timi"
                 >
                   <div
                     class="ant-web3-connect-modal-list-panel"
@@ -1027,10 +1027,10 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -1050,13 +1050,13 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=0"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1075,13 +1075,13 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=3"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet3
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1106,10 +1106,10 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -1129,13 +1129,13 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=1"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet2
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1153,13 +1153,13 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet4
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1177,13 +1177,13 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet5
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1201,13 +1201,13 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1225,13 +1225,13 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1275,7 +1275,7 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-17seli4"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-m4timi"
                           >
                             <img
                               src="https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*ApSUSaoUa_sAAAAAAAAAAAAADlrGAQ/original"
@@ -1300,7 +1300,7 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-17seli4"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-m4timi"
                           >
                             <img
                               src="https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*3lD7QpnbCPcAAAAAAAAAAAAADlrGAQ/original"
@@ -1325,7 +1325,7 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-17seli4"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-m4timi"
                           >
                             <img
                               src="https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*gTROQqEY_TcAAAAAAAAAAAAADlrGAQ/original"
@@ -1348,7 +1348,7 @@ exports[`ConnectModal with guide > should display default guide 1`] = `
                         </div>
                       </div>
                       <a
-                        class="ant-btn css-dev-only-do-not-override-17seli4 ant-btn-default ant-btn-lg ant-btn-block ant-web3-connect-modal-more"
+                        class="ant-btn css-dev-only-do-not-override-m4timi ant-btn-default ant-btn-lg ant-btn-block ant-web3-connect-modal-more"
                         href="https://ethereum.org/en/wallets/"
                         tabindex="0"
                         target="_blank"
@@ -1380,7 +1380,7 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
   <div />
   <div>
     <div
-      class="ant-modal-root css-dev-only-do-not-override-1fp6a1c ant-web3-connect-modal-root"
+      class="ant-modal-root css-dev-only-do-not-override-1klkdex ant-web3-connect-modal-root"
     >
       <div
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
@@ -1391,7 +1391,7 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
       >
         <div
           aria-modal="true"
-          class="ant-modal css-dev-only-do-not-override-1fp6a1c ant-web3-connect-modal css-dev-only-do-not-override-1fp6a1c ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
+          class="ant-modal css-dev-only-do-not-override-1klkdex ant-web3-connect-modal css-dev-only-do-not-override-1klkdex ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
           role="dialog"
           style="width: 797px;"
         >
@@ -1441,7 +1441,7 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                 class="ant-modal-body"
               >
                 <div
-                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-1fp6a1c"
+                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-1klkdex"
                 >
                   <div
                     class="ant-web3-connect-modal-list-panel"
@@ -1476,10 +1476,10 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-1fp6a1c"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-1klkdex"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-1fp6a1c"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-1klkdex"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -1499,13 +1499,13 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=0"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1524,13 +1524,13 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=3"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet3
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1555,10 +1555,10 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-1fp6a1c"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-1klkdex"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-1fp6a1c"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-1klkdex"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -1578,13 +1578,13 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=1"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet2
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1602,13 +1602,13 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet4
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1626,13 +1626,13 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet5
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1650,13 +1650,13 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1674,13 +1674,13 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1724,7 +1724,7 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-1fp6a1c"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-1klkdex"
                           >
                             <img
                               src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=4"
@@ -1749,7 +1749,7 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-1fp6a1c"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-1klkdex"
                           >
                             <img
                               src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=5"
@@ -1774,7 +1774,7 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-1fp6a1c"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-1klkdex"
                           >
                             <img
                               src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=5"
@@ -1799,7 +1799,7 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-1fp6a1c"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-1klkdex"
                           >
                             <img
                               src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=5"
@@ -1822,7 +1822,7 @@ exports[`ConnectModal with guide > should render in dark mode 1`] = `
                         </div>
                       </div>
                       <a
-                        class="ant-btn css-dev-only-do-not-override-1fp6a1c ant-btn-default ant-btn-lg ant-btn-block ant-web3-connect-modal-more"
+                        class="ant-btn css-dev-only-do-not-override-1klkdex ant-btn-default ant-btn-lg ant-btn-block ant-web3-connect-modal-more"
                         href="https://test.com/xxx"
                         tabindex="0"
                         target="_blank"
@@ -1854,7 +1854,7 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
   <div />
   <div>
     <div
-      class="ant-modal-root css-dev-only-do-not-override-17seli4 ant-web3-connect-modal-root"
+      class="ant-modal-root css-dev-only-do-not-override-m4timi ant-web3-connect-modal-root"
     >
       <div
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
@@ -1865,7 +1865,7 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
       >
         <div
           aria-modal="true"
-          class="ant-modal css-dev-only-do-not-override-17seli4 ant-web3-connect-modal css-dev-only-do-not-override-17seli4 ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
+          class="ant-modal css-dev-only-do-not-override-m4timi ant-web3-connect-modal css-dev-only-do-not-override-m4timi ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
           role="dialog"
           style="width: 797px;"
         >
@@ -1915,7 +1915,7 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                 class="ant-modal-body"
               >
                 <div
-                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-17seli4"
+                  class="ant-web3-connect-modal-body css-dev-only-do-not-override-m4timi"
                 >
                   <div
                     class="ant-web3-connect-modal-list-panel"
@@ -1950,10 +1950,10 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -1973,13 +1973,13 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=0"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -1998,13 +1998,13 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=3"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet3
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -2029,10 +2029,10 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -2052,13 +2052,13 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=1"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet2
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -2076,13 +2076,13 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet4
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -2100,13 +2100,13 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet5
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -2124,13 +2124,13 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -2148,13 +2148,13 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -2198,7 +2198,7 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-17seli4"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-m4timi"
                           >
                             <img
                               src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=4"
@@ -2223,7 +2223,7 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-17seli4"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-m4timi"
                           >
                             <img
                               src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=5"
@@ -2248,7 +2248,7 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-17seli4"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-m4timi"
                           >
                             <img
                               src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=5"
@@ -2273,7 +2273,7 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                           class="ant-web3-connect-modal-guide-item"
                         >
                           <span
-                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-17seli4"
+                            class="ant-avatar ant-avatar-square ant-avatar-image ant-web3-connect-modal-guide-item-icon css-dev-only-do-not-override-m4timi"
                           >
                             <img
                               src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=5"
@@ -2296,7 +2296,7 @@ exports[`ConnectModal with guide > should render in light mode 1`] = `
                         </div>
                       </div>
                       <a
-                        class="ant-btn css-dev-only-do-not-override-17seli4 ant-btn-default ant-btn-lg ant-btn-block ant-web3-connect-modal-more"
+                        class="ant-btn css-dev-only-do-not-override-m4timi ant-btn-default ant-btn-lg ant-btn-block ant-web3-connect-modal-more"
                         href="https://test.com/xxx"
                         tabindex="0"
                         target="_blank"

--- a/packages/web3/src/connect-modal/__tests__/__snapshots__/simple.test.tsx.snap
+++ b/packages/web3/src/connect-modal/__tests__/__snapshots__/simple.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
   <div />
   <div>
     <div
-      class="ant-modal-root css-dev-only-do-not-override-1fp6a1c ant-web3-connect-modal-root"
+      class="ant-modal-root css-dev-only-do-not-override-1klkdex ant-web3-connect-modal-root"
     >
       <div
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
@@ -16,7 +16,7 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
       >
         <div
           aria-modal="true"
-          class="ant-modal css-dev-only-do-not-override-1fp6a1c ant-web3-connect-modal css-dev-only-do-not-override-1fp6a1c ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
+          class="ant-modal css-dev-only-do-not-override-1klkdex ant-web3-connect-modal css-dev-only-do-not-override-1klkdex ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
           role="dialog"
           style="width: 380px;"
         >
@@ -66,7 +66,7 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                 class="ant-modal-body"
               >
                 <div
-                  class="ant-web3-connect-modal-body ant-web3-connect-modal-body-simple css-dev-only-do-not-override-1fp6a1c"
+                  class="ant-web3-connect-modal-body ant-web3-connect-modal-body-simple css-dev-only-do-not-override-1klkdex"
                 >
                   <div
                     class="ant-web3-connect-modal-list-panel"
@@ -101,10 +101,10 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-1fp6a1c"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-1klkdex"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-1fp6a1c"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-1klkdex"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -124,13 +124,13 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=0"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -149,13 +149,13 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=3"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet3
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -180,10 +180,10 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-1fp6a1c"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-1klkdex"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-1fp6a1c"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-1klkdex"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -203,13 +203,13 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=1"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet2
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -227,13 +227,13 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet4
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -251,13 +251,13 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet5
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -275,13 +275,13 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -299,13 +299,13 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1fp6a1c"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-1klkdex"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-1fp6a1c ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-1klkdex ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -328,7 +328,7 @@ exports[`ConnectModal without guide > should render in dark mode 1`] = `
                         >
                           New to crypto wallets?
                           <button
-                            class="ant-btn css-dev-only-do-not-override-1fp6a1c ant-btn-link ant-btn-sm ant-web3-connect-modal-simple-guide-right"
+                            class="ant-btn css-dev-only-do-not-override-1klkdex ant-btn-link ant-btn-sm ant-web3-connect-modal-simple-guide-right"
                             type="button"
                           >
                             <span>
@@ -365,7 +365,7 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
   <div />
   <div>
     <div
-      class="ant-modal-root css-dev-only-do-not-override-17seli4 ant-web3-connect-modal-root"
+      class="ant-modal-root css-dev-only-do-not-override-m4timi ant-web3-connect-modal-root"
     >
       <div
         class="ant-modal-mask ant-fade-appear ant-fade-appear-start ant-fade"
@@ -376,7 +376,7 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
       >
         <div
           aria-modal="true"
-          class="ant-modal css-dev-only-do-not-override-17seli4 ant-web3-connect-modal css-dev-only-do-not-override-17seli4 ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
+          class="ant-modal css-dev-only-do-not-override-m4timi ant-web3-connect-modal css-dev-only-do-not-override-m4timi ant-zoom-appear ant-zoom-appear-prepare ant-zoom"
           role="dialog"
           style="width: 380px;"
         >
@@ -426,7 +426,7 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                 class="ant-modal-body"
               >
                 <div
-                  class="ant-web3-connect-modal-body ant-web3-connect-modal-body-simple css-dev-only-do-not-override-17seli4"
+                  class="ant-web3-connect-modal-body ant-web3-connect-modal-body-simple css-dev-only-do-not-override-m4timi"
                 >
                   <div
                     class="ant-web3-connect-modal-list-panel"
@@ -461,10 +461,10 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -484,13 +484,13 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=0"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -509,13 +509,13 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=3"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet3
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -540,10 +540,10 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                               class="ant-web3-connect-modal-group-content"
                             >
                               <div
-                                class="ant-list ant-list-split css-dev-only-do-not-override-17seli4"
+                                class="ant-list ant-list-split css-dev-only-do-not-override-m4timi"
                               >
                                 <div
-                                  class="ant-spin-nested-loading css-dev-only-do-not-override-17seli4"
+                                  class="ant-spin-nested-loading css-dev-only-do-not-override-m4timi"
                                 >
                                   <div
                                     class="ant-spin-container"
@@ -563,13 +563,13 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                                             src="https://xsgames.co/randomusers/avatar.php?g=pixel&key=1"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet2
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -587,13 +587,13 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet4
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -611,13 +611,13 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet5
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -635,13 +635,13 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -659,13 +659,13 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                                             class="ant-web3-connect-modal-img"
                                           />
                                           <span
-                                            class="ant-typography ant-typography-ellipsis ant-typography-single-line ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-17seli4"
+                                            class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line ant-web3-connect-modal-name css-dev-only-do-not-override-m4timi"
                                           >
                                             Test Wallet6
                                           </span>
                                         </div>
                                         <div
-                                          class="ant-space css-dev-only-do-not-override-17seli4 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                                          class="ant-space css-dev-only-do-not-override-m4timi ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                                         >
                                           <div
                                             class="ant-space-item"
@@ -688,7 +688,7 @@ exports[`ConnectModal without guide > should render in light mode 1`] = `
                         >
                           New to crypto wallets?
                           <button
-                            class="ant-btn css-dev-only-do-not-override-17seli4 ant-btn-link ant-btn-sm ant-web3-connect-modal-simple-guide-right"
+                            class="ant-btn css-dev-only-do-not-override-m4timi ant-btn-link ant-btn-sm ant-web3-connect-modal-simple-guide-right"
                             type="button"
                           >
                             <span>

--- a/packages/web3/src/nft-image/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/web3/src/nft-image/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`NFTImage > use custom getNFTMetadata 1`] = `
 <body>
   <div>
     <div
-      class="ant-image css-dev-only-do-not-override-17seli4"
+      class="ant-image css-dev-only-do-not-override-m4timi"
     >
       <img
         alt="Test_0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B_123"
-        class="ant-image-img css-dev-only-do-not-override-17seli4"
+        class="ant-image-img css-dev-only-do-not-override-m4timi"
         src="https://example.com/nft.png"
         style="image-rendering: pixelated;"
       />

--- a/packages/web3/src/web3-config-provider/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/web3/src/web3-config-provider/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`web3-config-provider > Should work 1`] = `
 <body>
   <div>
     <button
-      class="ant-btn css-dev-only-do-not-override-17seli4 ant-btn-default ant-web3-connect-button css-dev-only-do-not-override-17seli4"
+      class="ant-btn css-dev-only-do-not-override-m4timi ant-btn-default ant-web3-connect-button css-dev-only-do-not-override-m4timi"
       type="button"
     >
       <div
@@ -49,23 +49,27 @@ exports[`web3-config-provider > useNFT with custom getNFTMetadata 1`] = `
     <div
       aria-busy="false"
       aria-live="polite"
-      class="ant-spin css-dev-only-do-not-override-17seli4"
+      class="ant-spin css-dev-only-do-not-override-m4timi"
     >
       <span
-        class="ant-spin-dot ant-spin-dot-spin"
+        class="ant-spin-dot-holder"
       >
-        <i
-          class="ant-spin-dot-item"
-        />
-        <i
-          class="ant-spin-dot-item"
-        />
-        <i
-          class="ant-spin-dot-item"
-        />
-        <i
-          class="ant-spin-dot-item"
-        />
+        <span
+          class="ant-spin-dot ant-spin-dot-spin"
+        >
+          <i
+            class="ant-spin-dot-item"
+          />
+          <i
+            class="ant-spin-dot-item"
+          />
+          <i
+            class="ant-spin-dot-item"
+          />
+          <i
+            class="ant-spin-dot-item"
+          />
+        </span>
       </span>
     </div>
   </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@ant-design/cssinjs':
-        specifier: ^1.20.0
+        specifier: ^1.21.0
         version: 1.21.0(react-dom@18.2.0)(react@18.2.0)
       '@ant-design/icons':
         specifier: ^5.3.7
@@ -72,13 +72,13 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3(react@18.2.0)
       react:
-        specifier: ^18.2.0
+        specifier: 18.2.0
         version: 18.2.0
       react-copy-to-clipboard:
         specifier: ^5.1.0
         version: 5.1.0(react@18.2.0)
       react-dom:
-        specifier: ^18.2.0
+        specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       viem:
         specifier: ^2.16.5
@@ -619,8 +619,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3(react@18.2.0)
       antd:
-        specifier: ^5.17.3
-        version: 5.17.3(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^5.18.3
+        version: 5.18.3(react-dom@18.2.0)(react@18.2.0)
       bs58:
         specifier: ^5.0.0
         version: 5.0.0
@@ -5852,7 +5852,7 @@ packages:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
       debug: 4.3.5(supports-color@5.5.0)
-      semver: 7.5.4
+      semver: 7.6.2
       superstruct: 1.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6714,7 +6714,7 @@ packages:
       hermes-profile-transformer: 0.0.6
       node-stream-zip: 1.15.0
       ora: 5.4.1
-      semver: 7.5.4
+      semver: 7.6.2
       strip-ansi: 5.2.0
       wcwidth: 1.0.1
       yaml: 2.3.4
@@ -6786,7 +6786,7 @@ packages:
       node-fetch: 2.7.0
       open: 6.4.0
       ora: 5.4.1
-      semver: 7.5.4
+      semver: 7.6.2
       shell-quote: 1.8.1
       sudo-prompt: 9.2.1
     transitivePeerDependencies:
@@ -6819,7 +6819,7 @@ packages:
       fs-extra: 8.1.0
       graceful-fs: 4.2.11
       prompts: 2.4.2
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -21653,7 +21653,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       react: 18.2.0
-      scheduler: 0.23.0
+      scheduler: 0.23.2
 
   /react-dom@18.3.1(react@18.3.1):
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -22671,16 +22671,10 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
-  /scheduler@0.23.0:
-    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
-    dependencies:
-      loose-envify: 1.4.0
-
   /scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /scheduler@0.24.0-canary-efb381bbf-20230505:
     resolution: {integrity: sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==}
@@ -22747,7 +22741,6 @@ packages:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: false
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}


### PR DESCRIPTION
问题可能出在计算移至cssinjs这个更新，这个pr主要做了两处调整，1: cssinjs to 1.21.0 和 antd to 5.18.3，2. react 和 react-dom的锁死，不然可能ci会有很多报错，我在后面升级下一个antd版本的时候，react的版本和那边一起对齐好了。 我是想着antd5.19这个月初才刚发，我们可以等到月中或者月底再做升级。
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/f991a64a-7553-4b2f-8cf9-f529f0bc574f)
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/e71afafb-1629-43ad-8e26-8d6e6e6edcf5)

目前fix了。close #1023 
![image](https://github.com/ant-design/ant-design-web3/assets/117748716/1ba46e3f-445d-4688-b7ce-b74a9d2ffe9d)
