### PR TITLE
chore: Test script support specify package range

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@changesets/changelog-git": "^0.2.0",
     "@changesets/cli": "^2.27.7",
     "@ianvs/prettier-plugin-sort-imports": "^4.2.1",
+    "@inquirer/checkbox": "^2.3.10",
     "@testing-library/react": "^16.0.0",
     "@types/lodash": "^4.17.6",
     "@types/node": "^20.14.10",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:dist": "cross-env LIB_DIR=dist vitest",
     "test:update": "vitest -u",
     "test:coverage": "vitest --coverage",
-    "test:ci": "cross-env LIB_DIR=normal vitest --coverage",
+    "test:ci": "cross-env LIB_DIR=normal vitest --coverage -- --pkg=*",
     "lint": "pnpm run \"/^lint:.+/\"",
     "lint:eslint": "eslint --ext .ts,.tsx .",
     "eslint": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "release:beta": "pnpm run release:prepare && changeset version --snapshot beta && changeset publish --tag beta",
     "ci": "npm run build && npm run lint && npm run test:dist && npm run test:ci",
     "test": "vitest",
-    "test:dist": "cross-env LIB_DIR=dist vitest",
+    "test:dist": "cross-env LIB_DIR=dist vitest -- --pkg=*",
     "test:update": "vitest -u",
     "test:coverage": "vitest --coverage",
     "test:ci": "cross-env LIB_DIR=normal vitest --coverage -- --pkg=*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.2.1
         version: 4.2.1(prettier@3.3.2)
+      '@inquirer/checkbox':
+        specifier: ^2.3.10
+        version: 2.3.10
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.0.0(@testing-library/dom@10.1.0)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
@@ -5364,6 +5367,48 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@inquirer/checkbox@2.3.10:
+    resolution: {integrity: sha512-CTc864M2/523rKc9AglIzAcUCuPXDZENgc5S2KZFVRbnMzpXcYTsUWmbqSeL0XLvtlvEtNevkkVbfVhJpruOyQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/core': 9.0.2
+      '@inquirer/figures': 1.0.3
+      '@inquirer/type': 1.4.0
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    dev: true
+
+  /@inquirer/core@9.0.2:
+    resolution: {integrity: sha512-nguvH3TZar3ACwbytZrraRTzGqyxJfYJwv+ZwqZNatAosdWQMP1GV8zvmkNlBe2JeZSaw0WYBHZk52pDpWC9qA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/figures': 1.0.3
+      '@inquirer/type': 1.4.0
+      '@types/mute-stream': 0.0.4
+      '@types/node': 20.14.10
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      cli-spinners: 2.9.2
+      cli-width: 4.1.0
+      mute-stream: 1.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    dev: true
+
+  /@inquirer/figures@1.0.3:
+    resolution: {integrity: sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@inquirer/type@1.4.0:
+    resolution: {integrity: sha512-AjOqykVyjdJQvtfkNDGUyMYGF8xN50VUxftCQWsOyIo4DFRLr6VQhW0VItGI1JIyQGCGgIpKa7hMMwNhZb4OIw==}
+    engines: {node: '>=18'}
+    dependencies:
+      mute-stream: 1.0.0
+    dev: true
+
   /@ioredis/commands@1.2.0:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
 
@@ -8708,6 +8753,12 @@ packages:
   /@types/ms@0.7.34:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
+  /@types/mute-stream@0.0.4:
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+    dependencies:
+      '@types/node': 20.14.10
+    dev: true
+
   /@types/node@11.11.6:
     resolution: {integrity: sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==}
     dev: false
@@ -8811,6 +8862,10 @@ packages:
   /@types/unist@2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
     dev: false
+
+  /@types/wrap-ansi@3.0.0:
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
+    dev: true
 
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
@@ -12550,6 +12605,11 @@ packages:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
     dev: false
+
+  /cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+    dev: true
 
   /click-to-react-component@1.1.0(@types/react@18.2.78)(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-/DjZemufS1BkxyRgZL3r7HXVVOFRWVQi5Xd4EBnjxZMwrHEh0OlUVA2N9CjXkZ0x8zMf8dL1cKnnx+xUWUg4VA==}
@@ -18970,6 +19030,11 @@ packages:
   /mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     dev: false
+
+  /mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
 
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -25806,6 +25871,11 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: true
+
+  /yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
     dev: true
 
   /z-schema@5.0.5:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,6 +13,7 @@ const isDist = process.env.LIB_DIR === 'dist';
 const pkgList = readdirSync(path.join(__dirname, 'packages'));
 
 // Examples:
+//   pnpm test -- --pkg=*
 //   pnpm test -- --pkg=wagmi
 //   pnpm test -- --pkg=solana,wagmi
 const pkg = process.argv.find(arg => arg.startsWith('--pkg='));

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -38,7 +38,7 @@ if (packages.length) {
   console.warn(`Testing all packages\r\n`);
 }
 
-const testPackages = packages.length > 1 ? `{${packages.join(',')}}` : packages.join('');
+const testPackages = packages.length > 1 ? `{${packages.join(',')}}` : packages[0];
 
 export default defineConfig({
   plugins: [

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,6 +8,19 @@ const resolve = (src: string) => {
 
 const isDist = process.env.LIB_DIR === 'dist';
 
+// Examples:
+//   pnpm test -- --pkg=wagmi
+//   pnpm test -- --pkg=solana,wagmi
+const pkg = process.argv.find(arg => arg.startsWith('--pkg='));
+const pkgValue = pkg ? pkg.split('=')[1] : '';
+const packages = pkgValue ?
+  pkgValue.includes(',') ? `{${pkgValue}}` : pkgValue
+  : '';
+
+if (packages) {
+  console.warn(`Testing packages: [${pkgValue}]\r\n`);
+}
+
 export default defineConfig({
   plugins: [
     svgr({
@@ -56,11 +69,11 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    include: ['./packages/**/*.test.{ts,tsx}'],
+    include: [`./packages${packages ? ('/' + packages) : ''}/**/*.test.{ts,tsx}`],
     setupFiles: ['./tests/setup.ts'],
     reporters: ['default'],
     coverage: {
-      include: ['packages/*/src/**/*.{ts,tsx}'],
+      include: [`packages/${packages ? packages : '*'}/src/**/*.{ts,tsx}`],
       exclude: ['**/demos/*.{ts,tsx}', '**/src/index.ts'],
       reporter: ['json-summary', ['text', { skipFull: true }], 'cobertura', 'html'],
     },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,8 +20,7 @@ const pkg = process.argv.find(arg => arg.startsWith('--pkg='));
 let packages: string[] = [];
 
 if (pkg) {
-  const pkgValue = pkg ? pkg.split('=')[1] : '';
-  packages = pkgValue.split(',');
+  packages = pkg.split('=')[1].split(',');
 } else {
   packages = await checkbox({
     message: 'Select packages to test (Enter to select all):',


### PR DESCRIPTION
运行测试命令时，支持指定范围。

## 💡 Background and solution

由于项目文件越来越多，本地开发时执行测试命令时运行时间越来越久。但是在本地开发时，其实大部分只需要测试部分内容。这个 PR 添加了 `--pkg` 参数，可以指定测试范围。

### 使用方式
```bash
pnpm test -- --pkg=solana
pnpm test:coverage -- --pkg=solana

# 多个 package
pnpm test -- --pkg=wagmi,solana

# 使用通配符（需要加上引号）
pnpm test -- --pkg="ethers*"
```

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
