### PR TITLE
fix(connect-button): width is fit-content when quickConnect

### DIFF
--- a/.changeset/gold-pots-join.md
+++ b/.changeset/gold-pots-join.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix(connect-button): width is fit-content when the ConnectButton is set to quick

--- a/packages/web3/src/connect-button/style/index.ts
+++ b/packages/web3/src/connect-button/style/index.ts
@@ -62,6 +62,7 @@ const genConnectButtonStyle: GenerateStyle<ConnectButtonToken> = (token) => {
     },
 
     [`${token.componentCls}-quick-connect`]: {
+      width: 'fit-content',
       [`${token.componentCls}-quick-connect-icon`]: {
         marginLeft: token.marginXS,
       },


### PR DESCRIPTION
…et to quick

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

before:

![image](https://github.com/user-attachments/assets/5ccd83c1-855c-4702-ac9b-29d9aef925cf)

after: 

![image](https://github.com/user-attachments/assets/a2d48182-226c-4510-9136-bd8a81a061f0)


<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

## 🔗 Related issue link
close: #1035 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
