### PR TITLE
build: filter out packages that not actually exist

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -1,18 +1,25 @@
-import { readdirSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { defineConfig } from 'dumi';
 
 // utils must build before core
 // runtime must build before renderer-react
-const pkgList = readdirSync(join(__dirname, 'packages')).map((pkg) => {
-  const packageJson = require(join(__dirname, 'packages', pkg, 'package.json'));
+const pkgList = readdirSync(join(__dirname, 'packages'))
+  .map((pkg) => {
+    const packagePath = join(__dirname, 'packages', pkg, 'package.json');
+    if (!existsSync(packagePath)) {
+      return;
+    }
 
-  return {
-    name: packageJson.name,
-    exports: packageJson.exports,
-    path: join(__dirname, 'packages', pkg, 'src'),
-  };
-});
+    const packageJson = require(packagePath);
+
+    return {
+      name: packageJson.name,
+      exports: packageJson.exports,
+      path: join(__dirname, 'packages', pkg, 'src'),
+    };
+  })
+  .filter((v) => !!v);
 
 const alias = pkgList.reduce(
   (pre, pkg) => {


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

本地有未合并的 packages 且切换分支时，可能会有一些空的包目录，脚本中过滤一下。

<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
