### PR TITLE
docs(icons): improve styles by adjust z-index

### DIFF
--- a/.dumi/theme/common/styles/Icon.tsx
+++ b/.dumi/theme/common/styles/Icon.tsx
@@ -103,6 +103,7 @@ const Icon: React.FC = () => {
           opacity: 0;
           transition: all 0.3s cubic-bezier(0.18, 0.89, 0.32, 1.28);
           content: 'Copied!';
+          z-index: -1;
         }
 
         &.copied::after {


### PR DESCRIPTION
## 💡 Background and solution

优化一下图标页面样式，方便使用 右键 - 检查元素 的时候直接定位到 svg DOM。现在是定位到了外层元素，不太方便😵‍💫。

## 🔗 Related issue link
