### PR TITLE
chore: release 1.16.0 & @ant-design/web3-ton 1.0

### DIFF
--- a/.changeset/chilled-birds-help.md
+++ b/.changeset/chilled-birds-help.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix: ConnectModal style bug in dark theme

--- a/.changeset/few-onions-buy.md
+++ b/.changeset/few-onions-buy.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix(ProfileModal): footer button overflow in custom token

--- a/.changeset/few-tools-perform.md
+++ b/.changeset/few-tools-perform.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix: improve crypto-input

--- a/.changeset/fluffy-dingos-guess.md
+++ b/.changeset/fluffy-dingos-guess.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix: use colorPrimaryTextHover for ConnectModal text hover style

--- a/.changeset/gold-pots-join.md
+++ b/.changeset/gold-pots-join.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix(connect-button): width is fit-content when the ConnectButton is set to quick

--- a/.changeset/green-teachers-bow.md
+++ b/.changeset/green-teachers-bow.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3-assets': minor
----
-
-feat(assets): Add USDC token

--- a/.changeset/healthy-penguins-look.md
+++ b/.changeset/healthy-penguins-look.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3-icons': minor
----
-
-feat(icons): Add Suiet wallet icons

--- a/.changeset/moody-beers-dream.md
+++ b/.changeset/moody-beers-dream.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix: ConnectButton text color in primary type

--- a/.changeset/nasty-windows-tie.md
+++ b/.changeset/nasty-windows-tie.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': minor
----
-
-feat: TokenSelect Component Support Multiple Mode

--- a/.changeset/orange-apes-taste.md
+++ b/.changeset/orange-apes-taste.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3-assets': minor
----
-
-feat: Add Tronlink icon

--- a/.changeset/shaggy-bugs-stare.md
+++ b/.changeset/shaggy-bugs-stare.md
@@ -1,7 +1,0 @@
----
-'@ant-design/web3-bitcoin': patch
-'@ant-design/web3-wagmi': patch
-'@ant-design/web3': patch
----
-
-chore: code style format

--- a/.changeset/sour-boats-flow.md
+++ b/.changeset/sour-boats-flow.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix(crypto-input): fix token style

--- a/.changeset/strong-islands-happen.md
+++ b/.changeset/strong-islands-happen.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix(connect-modal): footer-container mask width overflow

--- a/.changeset/ten-elephants-do.md
+++ b/.changeset/ten-elephants-do.md
@@ -1,6 +1,0 @@
----
-'@ant-design/web3-ton': major
-'@ant-design/web3': minor
----
-
-feat: add ton chain

--- a/.changeset/weak-dancers-lick.md
+++ b/.changeset/weak-dancers-lick.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3-icons': minor
----
-
-feat: add icons

--- a/.changeset/wicked-buttons-cover.md
+++ b/.changeset/wicked-buttons-cover.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix: ConnectModal get more btn link color design token bug

--- a/examples/eth-web3js/CHANGELOG.md
+++ b/examples/eth-web3js/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @example/eth-web3js
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [f188f8c]
+- Updated dependencies [2f55bec]
+- Updated dependencies [deae4aa]
+- Updated dependencies [fd1f6fa]
+- Updated dependencies [8c5e50b]
+- Updated dependencies [8f3430b]
+- Updated dependencies [aff7e1e]
+- Updated dependencies [0886599]
+- Updated dependencies [d663c3b]
+- Updated dependencies [3727e20]
+- Updated dependencies [ed69c53]
+- Updated dependencies [868e6fc]
+- Updated dependencies [d49a4b8]
+- Updated dependencies [fd1f6fa]
+  - @ant-design/web3@1.16.0
+  - @ant-design/web3-assets@1.10.0
+  - @ant-design/web3-eth-web3js@1.1.4
+
 ## 0.0.6
 
 ### Patch Changes

--- a/examples/eth-web3js/package.json
+++ b/examples/eth-web3js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/eth-web3js",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers-v5/CHANGELOG.md
+++ b/examples/ethers-v5/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @example/ethers-v5
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [f188f8c]
+- Updated dependencies [2f55bec]
+- Updated dependencies [deae4aa]
+- Updated dependencies [fd1f6fa]
+- Updated dependencies [8c5e50b]
+- Updated dependencies [8f3430b]
+- Updated dependencies [aff7e1e]
+- Updated dependencies [0886599]
+- Updated dependencies [d663c3b]
+- Updated dependencies [3727e20]
+- Updated dependencies [ed69c53]
+- Updated dependencies [868e6fc]
+- Updated dependencies [d49a4b8]
+- Updated dependencies [fd1f6fa]
+  - @ant-design/web3@1.16.0
+  - @ant-design/web3-assets@1.10.0
+  - @ant-design/web3-ethers-v5@1.0.5
+
 ## 0.0.6
 
 ### Patch Changes

--- a/examples/ethers-v5/package.json
+++ b/examples/ethers-v5/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers-v5",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers/CHANGELOG.md
+++ b/examples/ethers/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @example/ethers
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [f188f8c]
+- Updated dependencies [2f55bec]
+- Updated dependencies [deae4aa]
+- Updated dependencies [fd1f6fa]
+- Updated dependencies [8c5e50b]
+- Updated dependencies [8f3430b]
+- Updated dependencies [aff7e1e]
+- Updated dependencies [0886599]
+- Updated dependencies [d663c3b]
+- Updated dependencies [3727e20]
+- Updated dependencies [ed69c53]
+- Updated dependencies [868e6fc]
+- Updated dependencies [d49a4b8]
+- Updated dependencies [fd1f6fa]
+  - @ant-design/web3@1.16.0
+  - @ant-design/web3-assets@1.10.0
+  - @ant-design/web3-ethers@1.1.4
+
 ## 0.0.6
 
 ### Patch Changes

--- a/examples/ethers/package.json
+++ b/examples/ethers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @ant-design/web3-assets
 
+## 1.10.0
+
+### Minor Changes
+
+- 8f3430b: feat(assets): Add USDC token
+- d663c3b: feat: Add Tronlink icon
+
+### Patch Changes
+
+- Updated dependencies [cf6c044]
+- Updated dependencies [7d8f51f]
+  - @ant-design/web3-icons@1.8.0
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-assets",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/bitcoin/CHANGELOG.md
+++ b/packages/bitcoin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-bitcoin
 
+## 1.4.1
+
+### Patch Changes
+
+- 3727e20: chore: code style format
+- Updated dependencies [cf6c044]
+- Updated dependencies [7d8f51f]
+  - @ant-design/web3-icons@1.8.0
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-bitcoin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/eth-web3js/CHANGELOG.md
+++ b/packages/eth-web3js/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3-eth-web3js
 
+## 1.1.4
+
+### Patch Changes
+
+- Updated dependencies [8f3430b]
+- Updated dependencies [d663c3b]
+- Updated dependencies [3727e20]
+  - @ant-design/web3-assets@1.10.0
+  - @ant-design/web3-wagmi@2.7.1
+
 ## 1.1.3
 
 ### Patch Changes

--- a/packages/eth-web3js/package.json
+++ b/packages/eth-web3js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-eth-web3js",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers-v5/CHANGELOG.md
+++ b/packages/ethers-v5/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ant-design/web3-ethers-v5
 
+## 1.0.5
+
+### Patch Changes
+
+- Updated dependencies [8f3430b]
+- Updated dependencies [d663c3b]
+- Updated dependencies [3727e20]
+  - @ant-design/web3-assets@1.10.0
+  - @ant-design/web3-wagmi@2.7.1
+  - @ant-design/web3-ethers@1.1.4
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/ethers-v5/package.json
+++ b/packages/ethers-v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers-v5",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3-ethers
 
+## 1.1.4
+
+### Patch Changes
+
+- Updated dependencies [8f3430b]
+- Updated dependencies [d663c3b]
+- Updated dependencies [3727e20]
+  - @ant-design/web3-assets@1.10.0
+  - @ant-design/web3-wagmi@2.7.1
+
 ## 1.1.3
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ant-design/web3-icons
 
+## 1.8.0
+
+### Minor Changes
+
+- cf6c044: feat(icons): Add Suiet wallet icons
+- 7d8f51f: feat: add icons
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-icons",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ant-design/web3-solana
 
+## 1.1.8
+
+### Patch Changes
+
+- Updated dependencies [8f3430b]
+- Updated dependencies [d663c3b]
+  - @ant-design/web3-assets@1.10.0
+
 ## 1.1.7
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-solana",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/ton/CHANGELOG.md
+++ b/packages/ton/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @ant-design/web3-ton
+
+## 1.0.0
+
+### Major Changes
+
+- d49a4b8: feat: add ton chain
+
+### Patch Changes
+
+- Updated dependencies [8f3430b]
+- Updated dependencies [d663c3b]
+  - @ant-design/web3-assets@1.10.0

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ton",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/wagmi/CHANGELOG.md
+++ b/packages/wagmi/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-wagmi
 
+## 2.7.1
+
+### Patch Changes
+
+- 3727e20: chore: code style format
+- Updated dependencies [8f3430b]
+- Updated dependencies [d663c3b]
+  - @ant-design/web3-assets@1.10.0
+
 ## 2.7.0
 
 ### Minor Changes

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-wagmi",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @ant-design/web3
 
+## 1.16.0
+
+### Minor Changes
+
+- 0886599: feat: TokenSelect Component Support Multiple Mode
+- d49a4b8: feat: add ton chain
+
+### Patch Changes
+
+- f188f8c: fix: ConnectModal style bug in dark theme
+- 2f55bec: fix(ProfileModal): footer button overflow in custom token
+- deae4aa: fix: improve crypto-input
+- fd1f6fa: fix: use colorPrimaryTextHover for ConnectModal text hover style
+- 8c5e50b: fix(connect-button): width is fit-content when the ConnectButton is set to quick
+- aff7e1e: fix: ConnectButton text color in primary type
+- 3727e20: chore: code style format
+- ed69c53: fix(crypto-input): fix token style
+- 868e6fc: fix(connect-modal): footer-container mask width overflow
+- fd1f6fa: fix: ConnectModal get more btn link color design token bug
+- Updated dependencies [8f3430b]
+- Updated dependencies [cf6c044]
+- Updated dependencies [d663c3b]
+- Updated dependencies [7d8f51f]
+  - @ant-design/web3-assets@1.10.0
+  - @ant-design/web3-icons@1.8.0
+
 ## 1.15.1
 
 ### Patch Changes

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
🦋  success packages published successfully:
🦋  @ant-design/web3-assets@1.10.0
🦋  @ant-design/web3-bitcoin@1.4.1
🦋  @ant-design/web3-eth-web3js@1.1.4
🦋  @ant-design/web3-ethers@1.1.4
🦋  @ant-design/web3-ethers-v5@1.0.5
🦋  @ant-design/web3-icons@1.8.0
🦋  @ant-design/web3-solana@1.1.8
🦋  @ant-design/web3-ton@1.0.0
🦋  @ant-design/web3-wagmi@2.7.1
🦋  @ant-design/web3@1.16.0