### PR TITLE
build: set targets chrome 100

### DIFF
--- a/.changeset/light-adults-relax.md
+++ b/.changeset/light-adults-relax.md
@@ -1,0 +1,15 @@
+---
+'@ant-design/web3-eth-web3js': minor
+'@ant-design/web3-ethers-v5': minor
+'@ant-design/web3-bitcoin': minor
+'@ant-design/web3-assets': minor
+'@ant-design/web3-common': minor
+'@ant-design/web3-ethers': minor
+'@ant-design/web3-solana': minor
+'@ant-design/web3-icons': minor
+'@ant-design/web3-wagmi': minor
+'@ant-design/web3': minor
+'@ant-design/web3-ton': minor
+---
+
+build: set targets chrome 100

--- a/.changeset/light-adults-relax.md
+++ b/.changeset/light-adults-relax.md
@@ -1,15 +1,15 @@
 ---
-'@ant-design/web3-eth-web3js': minor
-'@ant-design/web3-ethers-v5': minor
-'@ant-design/web3-bitcoin': minor
-'@ant-design/web3-assets': minor
-'@ant-design/web3-common': minor
-'@ant-design/web3-ethers': minor
-'@ant-design/web3-solana': minor
-'@ant-design/web3-icons': minor
-'@ant-design/web3-wagmi': minor
-'@ant-design/web3': minor
-'@ant-design/web3-ton': minor
+'@ant-design/web3-eth-web3js': patch
+'@ant-design/web3-ethers-v5': patch
+'@ant-design/web3-bitcoin': patch
+'@ant-design/web3-assets': patch
+'@ant-design/web3-common': patch
+'@ant-design/web3-ethers': patch
+'@ant-design/web3-solana': patch
+'@ant-design/web3-icons': patch
+'@ant-design/web3-wagmi': patch
+'@ant-design/web3': patch
+'@ant-design/web3-ton': patch
 ---
 
 build: set targets chrome 100

--- a/.fatherrc.base.ts
+++ b/.fatherrc.base.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     output: 'dist/esm',
     transformer: 'babel',
   },
+  targets: { chrome: 100 },
   extraBabelPlugins: [
     [
       'inline-react-svg',


### PR DESCRIPTION
## 💡 Background and solution

修改编译目标到 chrome 100，[antd 只支持现代浏览器](https://ant.design/docs/react/introduce-cn#%E5%85%BC%E5%AE%B9%E7%8E%AF%E5%A2%83)，这边支持过低的环境没有意义。


## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
