### PR TITLE
feat(web3-wagmi): Add 'initialState' and 'reconnectOnMount' props to WagmiWeb3ConfigProviderProps

### DIFF
--- a/.changeset/moody-elephants-talk.md
+++ b/.changeset/moody-elephants-talk.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3-wagmi': patch
+---
+
+feat(web3-wagmi): Add 'initialState' and 'reconnectOnMount' props to WagmiWeb3ConfigProviderProps

--- a/packages/wagmi/src/wagmi-provider/index.tsx
+++ b/packages/wagmi/src/wagmi-provider/index.tsx
@@ -4,7 +4,7 @@ import { Mainnet } from '@ant-design/web3-assets';
 import type { Chain, Locale } from '@ant-design/web3-common';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { WagmiProvider } from 'wagmi';
-import type { Config } from 'wagmi';
+import type { Config, State } from 'wagmi';
 
 import type { EIP6963Config, WalletFactory } from '../interface';
 import { AntDesignWeb3ConfigProvider } from './config-provider';
@@ -18,17 +18,19 @@ export type WagmiWeb3ConfigProviderProps = {
   queryClient?: QueryClient;
   balance?: boolean;
   eip6963?: EIP6963Config;
+  initialState?: State;
+  reconnectOnMount?: boolean;
 };
 
 export function WagmiWeb3ConfigProvider({
   children,
+  config,
+  locale,
   wallets = [],
   chains = [],
   ens,
-  locale,
-  balance,
-  config,
   queryClient,
+  balance,
   eip6963,
   ...restProps
 }: React.PropsWithChildren<WagmiWeb3ConfigProviderProps>): React.ReactElement {

--- a/packages/web3/src/ethereum/index.md
+++ b/packages/web3/src/ethereum/index.md
@@ -88,6 +88,8 @@ When the `showQrModal` configuration is not `false`, the built-in [web3modal](ht
 | balance | Whether to display balance | `boolean` | - | - |
 | locale | Multilingual settings | [Locale](https://github.com/ant-design/ant-design-web3/blob/main/packages/common/src/locale/en_US.ts) | - | - |
 | eip6963 | Whether to use EIP6963 protocol wallet and related configurations | `boolean` \| `EIP6963Config` | `false` |  |
+| initialState | Initial state to hydrate into the [Wagmi Config](https://wagmi.sh/react/api/createConfig). Useful for SSR. | [State](https://wagmi.sh/react/api/createConfig#state-1) \| `undefined` | - | - |
+| reconnectOnMount | Whether or not to reconnect previously connected [connectors](https://wagmi.sh/react/api/createConfig#connectors) on mount. | `boolean` \| `undefined` | `true` | - |
 
 ### WalletFactory
 

--- a/packages/web3/src/ethereum/index.zh-CN.md
+++ b/packages/web3/src/ethereum/index.zh-CN.md
@@ -87,6 +87,8 @@ Ant Design Web3 官方提供了 `wagmi`、`ethers` 等多个框架的适配器�
 | balance | 是否显示余额 | `boolean` | - | - |
 | locale | 多语言设置 | [Locale](https://github.com/ant-design/ant-design-web3/blob/main/packages/common/src/locale/zh_CN.ts) | - | - |
 | eip6963 | 是否采用 EIP6963 协议钱包以及相关配置 | `boolean` \| `EIP6963Config` | `false` | `2.2.0` |
+| initialState | [Wagmi 配置](https://wagmi.sh/react/api/createConfig)的初始状态，用于 SSR 预填充数据 | [State](https://wagmi.sh/core/config) \| `undefined` | - | - |
+| reconnectOnMount | 是否在组件挂载时重新连接之前已连接的[连接器](https://wagmi.sh/react/api/createConfig#connectors) | `boolean` \| `undefined` | `true` | - |
 
 ### EIP6963Config
 


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

To maintain consistency with the Wagmi, introduces `initialState` and `reconnectOnMount` properties, making component configuration options fully aligned with [WagmiProviderProps](https://github.com/wevm/wagmi/blob/main/packages/react/src/context.ts#L11-L15), facilitating seamless developer migration.

<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
