### PR TITLE
fix(web3-wagmi): Correct spelling of 'Factories'

### DIFF
--- a/.changeset/blue-games-happen.md
+++ b/.changeset/blue-games-happen.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3-wagmi': patch
+---
+
+fix(web3-wagmi): Correct spelling of "Factories"

--- a/packages/wagmi/src/wagmi-provider/__tests__/balance.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/balance.test.tsx
@@ -76,7 +76,7 @@ describe('WagmiWeb3ConfigProvider balance', () => {
     const App = () => (
       <AntDesignWeb3ConfigProvider
         balance
-        walletFactorys={[MetaMask()]}
+        walletFactories={[MetaMask()]}
         chainAssets={[Mainnet]}
         wagimConfig={config}
       >
@@ -105,7 +105,7 @@ describe('WagmiWeb3ConfigProvider balance', () => {
 
     const App = () => (
       <AntDesignWeb3ConfigProvider
-        walletFactorys={[MetaMask()]}
+        walletFactories={[MetaMask()]}
         chainAssets={[Mainnet]}
         wagimConfig={config}
       >

--- a/packages/wagmi/src/wagmi-provider/__tests__/connect-with-universal-wallet.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/connect-with-universal-wallet.test.tsx
@@ -122,7 +122,7 @@ describe('WagmiWeb3ConfigProvider connect with UniversalWallet', () => {
     const App = () => (
       <AntDesignWeb3ConfigProvider
         chainAssets={[Mainnet]}
-        walletFactorys={[TokenPocket()]}
+        walletFactories={[TokenPocket()]}
         wagimConfig={mockWagmiConfig}
       >
         <CustomConnector />
@@ -191,7 +191,7 @@ describe('WagmiWeb3ConfigProvider connect with UniversalWallet', () => {
     const App = () => (
       <AntDesignWeb3ConfigProvider
         chainAssets={[Mainnet]}
-        walletFactorys={[TokenPocket()]}
+        walletFactories={[TokenPocket()]}
         wagimConfig={mockWagmiConfig}
       >
         <CustomConnector />

--- a/packages/wagmi/src/wagmi-provider/__tests__/connect.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/connect.test.tsx
@@ -124,7 +124,7 @@ describe('WagmiWeb3ConfigProvider connect', () => {
 
     const App = () => (
       <AntDesignWeb3ConfigProvider
-        walletFactorys={[MetaMask()]}
+        walletFactories={[MetaMask()]}
         chainAssets={[Mainnet]}
         wagimConfig={mockWagmiConfig}
       >
@@ -194,7 +194,7 @@ describe('WagmiWeb3ConfigProvider connect', () => {
 
     const App = () => (
       <AntDesignWeb3ConfigProvider
-        walletFactorys={[MetaMask()]}
+        walletFactories={[MetaMask()]}
         chainAssets={[Mainnet]}
         wagimConfig={mockWagmiConfig}
       >

--- a/packages/wagmi/src/wagmi-provider/__tests__/ens.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/ens.test.tsx
@@ -89,7 +89,7 @@ describe('WagmiWeb3ConfigProvider ens', () => {
     const App = () => (
       <AntDesignWeb3ConfigProvider
         ens
-        walletFactorys={[MetaMask()]}
+        walletFactories={[MetaMask()]}
         chainAssets={[Mainnet]}
         wagimConfig={config}
       >
@@ -126,7 +126,7 @@ describe('WagmiWeb3ConfigProvider ens', () => {
     const App = () => (
       <AntDesignWeb3ConfigProvider
         ens
-        walletFactorys={[MetaMask()]}
+        walletFactories={[MetaMask()]}
         chainAssets={[Mainnet]}
         wagimConfig={config}
       >

--- a/packages/wagmi/src/wagmi-provider/__tests__/nft.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/nft.test.tsx
@@ -83,7 +83,7 @@ describe('WagmiWeb3ConfigProvider getMetadata', () => {
 
     const App = () => (
       <AntDesignWeb3ConfigProvider
-        walletFactorys={[MetaMask()]}
+        walletFactories={[MetaMask()]}
         chainAssets={[Mainnet]}
         wagimConfig={config}
       >

--- a/packages/wagmi/src/wagmi-provider/__tests__/switch-chain-unconnected.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/switch-chain-unconnected.test.tsx
@@ -76,7 +76,7 @@ describe('switch chain when not connected', () => {
 
     const App = () => (
       <AntDesignWeb3ConfigProvider
-        walletFactorys={[MetaMask()]}
+        walletFactories={[MetaMask()]}
         chainAssets={[Mainnet, Polygon]}
         wagimConfig={config}
       >

--- a/packages/wagmi/src/wagmi-provider/__tests__/switch-chain.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/switch-chain.test.tsx
@@ -92,7 +92,7 @@ describe('switch chain when connect', () => {
 
     const App = () => (
       <AntDesignWeb3ConfigProvider
-        walletFactorys={[MetaMask()]}
+        walletFactories={[MetaMask()]}
         chainAssets={[Mainnet, Polygon]}
         wagimConfig={config}
       >

--- a/packages/wagmi/src/wagmi-provider/config-provider.tsx
+++ b/packages/wagmi/src/wagmi-provider/config-provider.tsx
@@ -26,7 +26,7 @@ import { getNFTMetadata } from './methods';
 
 export interface AntDesignWeb3ConfigProviderProps {
   chainAssets: Chain[];
-  walletFactorys: WalletFactory[];
+  walletFactories: WalletFactory[];
   locale?: Locale;
   children?: React.ReactNode;
   ens?: boolean;
@@ -39,7 +39,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
   const {
     children,
     chainAssets,
-    walletFactorys,
+    walletFactories,
     ens = true,
     balance,
     locale,
@@ -83,7 +83,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
         if (
           typeof eip6963 === 'object' &&
           eip6963?.autoAddInjectedWallets &&
-          !walletFactorys.find((item) => item.connectors.includes(connector.name))
+          !walletFactories.find((item) => item.connectors.includes(connector.name))
         ) {
           // not config wallet and find the wallet in connectors, auto add it
           autoAddEIP6963Wallets.push(EIP6963Wallet().create([connector]));
@@ -92,7 +92,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
         return;
       }
 
-      const walletFactory = walletFactorys.find((factory) =>
+      const walletFactory = walletFactories.find((factory) =>
         factory.connectors.includes(connector.name),
       );
 
@@ -105,7 +105,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
     });
 
     // Generate Wallet for @ant-design/web3
-    const supportWallets = walletFactorys
+    const supportWallets = walletFactories
       .map((factory) => {
         const connectors = factory.connectors
           .map(findConnectorByName)
@@ -125,7 +125,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
       .filter((item) => item !== null) as Wallet[];
 
     return [...supportWallets, ...autoAddEIP6963Wallets];
-  }, [wagimConfig.connectors, walletFactorys, eip6963]);
+  }, [wagimConfig.connectors, walletFactories, eip6963]);
 
   const chainList: Chain[] = React.useMemo(() => {
     return wagimConfig.chains

--- a/packages/wagmi/src/wagmi-provider/index.tsx
+++ b/packages/wagmi/src/wagmi-provider/index.tsx
@@ -46,7 +46,7 @@ export function WagmiWeb3ConfigProvider({
         <AntDesignWeb3ConfigProvider
           locale={locale}
           chainAssets={chainAssets}
-          walletFactorys={wallets}
+          walletFactories={wallets}
           ens={ens}
           balance={balance}
           eip6963={eip6963}


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

Fixes a spelling error in the `walletFactories` prop name.

The word "Factories" was previously misspelled as "Factorys". This commit corrects the spelling.

<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

## 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
