### PR TITLE
feat: add addresses when multi address connected in onConnected

### DIFF
--- a/.changeset/nine-knives-live.md
+++ b/.changeset/nine-knives-live.md
@@ -1,0 +1,6 @@
+---
+'@ant-design/web3-common': minor
+'@ant-design/web3-wagmi': minor
+---
+
+feat: add addresses when multi address connected in onConnected

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -2,6 +2,7 @@ export interface Account {
   address: string;
   name?: string;
   avatar?: string;
+  accounts?: readonly [`0x${string}`, ...`0x${string}`[]];
 }
 
 export enum ChainIds {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -2,7 +2,7 @@ export interface Account {
   address: string;
   name?: string;
   avatar?: string;
-  accounts?: readonly [`0x${string}`, ...`0x${string}`[]];
+  addresses?: readonly [`0x${string}`, ...`0x${string}`[]];
 }
 
 export enum ChainIds {

--- a/packages/wagmi/src/wagmi-provider/__tests__/connect.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/connect.test.tsx
@@ -143,7 +143,7 @@ describe('WagmiWeb3ConfigProvider connect', () => {
     });
 
     expect(onConnected).toBeCalledWith({
-      accounts: [
+      addresses: [
         '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B',
         '0x0212f0974d53a6e96eF05d7B324a9803735fFd3B',
       ],

--- a/packages/wagmi/src/wagmi-provider/__tests__/connect.test.tsx
+++ b/packages/wagmi/src/wagmi-provider/__tests__/connect.test.tsx
@@ -143,6 +143,10 @@ describe('WagmiWeb3ConfigProvider connect', () => {
     });
 
     expect(onConnected).toBeCalledWith({
+      accounts: [
+        '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B',
+        '0x0212f0974d53a6e96eF05d7B324a9803735fFd3B',
+      ],
       address: '0x21CDf0974d53a6e96eF05d7B324a9803735fFd3B',
     });
 

--- a/packages/wagmi/src/wagmi-provider/config-provider.tsx
+++ b/packages/wagmi/src/wagmi-provider/config-provider.tsx
@@ -203,7 +203,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
         });
         return {
           address: accounts?.[0],
-          accounts,
+          addresses: accounts,
         };
       }}
       disconnect={async () => {

--- a/packages/wagmi/src/wagmi-provider/config-provider.tsx
+++ b/packages/wagmi/src/wagmi-provider/config-provider.tsx
@@ -203,6 +203,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<AntDesignWeb3ConfigProviderPr
         });
         return {
           address: accounts?.[0],
+          accounts,
         };
       }}
       disconnect={async () => {

--- a/packages/web3/src/types/index.md
+++ b/packages/web3/src/types/index.md
@@ -12,10 +12,11 @@ This defines the unified types of Ant Design Web3, which may be used in multiple
 
 ## Account
 
-| Property | Description                                | Type     | Default | Version |
-| -------- | ------------------------------------------ | -------- | ------- | ------- |
-| address  | Account address                            | `string` | -       | -       |
-| name     | Account name, For example, ENS in Ethereum | `string` | -       | -       |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| address | Account address (When multiple addresses are supported by the adapter, this represents the first address (`addresses[0]`)) | `string` | - | - |
+| name | Account name, For example, ENS in Ethereum | `string` | - | - |
+| addresses | List of wallet addresses authorized by the user (implemented by the adapter, supported in some chains) | `string[]` | - | - |
 
 ## ChainIds
 

--- a/packages/web3/src/types/index.zh-CN.md
+++ b/packages/web3/src/types/index.zh-CN.md
@@ -15,7 +15,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*n4F2RK3AVTsAAA
 
 | 属性      | 描述                                                   | 类型       | 默认值 | 版本 |
 | --------- | ------------------------------------------------------ | ---------- | ------ | ---- |
-| address   | 账户地址                                               | `string`   | -      | -    |
+| address   | 账户地址（适配器支持多地址时为 `addresses[0]`）        | `string`   | -      | -    |
 | name      | 账户名称，比如以太坊的 ENS                             | `string`   | -      | -    |
 | addresses | 用户授权的钱包地址列表（依赖适配器实现，部分链中支持） | `string[]` | -      | -    |
 

--- a/packages/web3/src/types/index.zh-CN.md
+++ b/packages/web3/src/types/index.zh-CN.md
@@ -13,10 +13,11 @@ coverDark: https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*n4F2RK3AVTsAAA
 
 ## Account
 
-| 属性    | 描述                       | 类型     | 默认值 | 版本 |
-| ------- | -------------------------- | -------- | ------ | ---- |
-| address | 账户地址                   | `string` | -      | -    |
-| name    | 账户名称，比如以太坊的 ENS | `string` | -      | -    |
+| 属性      | 描述                                                   | 类型       | 默认值 | 版本 |
+| --------- | ------------------------------------------------------ | ---------- | ------ | ---- |
+| address   | 账户地址                                               | `string`   | -      | -    |
+| name      | 账户名称，比如以太坊的 ENS                             | `string`   | -      | -    |
+| addresses | 用户授权的钱包地址列表（依赖适配器实现，部分链中支持） | `string[]` | -      | -    |
 
 ## ChainIds
 


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design-web3/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

## 💡 Background and solution

当多个钱包地址连接之后，onConnected 没有办法判断这种情况，因此需要在 connect 函数中返回全部连接的地址

## 🔗 Related issue link

close #1114 
