### PR TITLE
chore: release 1.17.0

### DIFF
--- a/.changeset/blue-kiwis-leave.md
+++ b/.changeset/blue-kiwis-leave.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3-ton': patch
----
-
-chore: add readme

--- a/.changeset/gorgeous-shoes-wash.md
+++ b/.changeset/gorgeous-shoes-wash.md
@@ -1,7 +1,0 @@
----
-'@ant-design/web3-common': minor
-'@ant-design/web3-wagmi': minor
-'@ant-design/web3': minor
----
-
-feat: support useWalletConnectOfficialModal for wagmi provider and add customQrCodePanel for wallet

--- a/.changeset/nine-knives-live.md
+++ b/.changeset/nine-knives-live.md
@@ -1,6 +1,0 @@
----
-'@ant-design/web3-common': minor
-'@ant-design/web3-wagmi': minor
----
-
-feat: add addresses when multi address connected in onConnected

--- a/.changeset/tasty-doors-shout.md
+++ b/.changeset/tasty-doors-shout.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3-icons': minor
----
-
-feat: add acala-circle-colorful and conflux-circle-colorful icons

--- a/.changeset/wild-ants-speak.md
+++ b/.changeset/wild-ants-speak.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': patch
----
-
-fix: remove useless margin in quick connect mode button

--- a/examples/eth-web3js/CHANGELOG.md
+++ b/examples/eth-web3js/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @example/eth-web3js
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+- Updated dependencies [a964d5d]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3@1.17.0
+  - @ant-design/web3-assets@1.11.1
+  - @ant-design/web3-eth-web3js@1.1.9
+
 ## 0.0.11
 
 ### Patch Changes

--- a/examples/eth-web3js/package.json
+++ b/examples/eth-web3js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/eth-web3js",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers-v5/CHANGELOG.md
+++ b/examples/ethers-v5/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @example/ethers-v5
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+- Updated dependencies [a964d5d]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3@1.17.0
+  - @ant-design/web3-assets@1.11.1
+  - @ant-design/web3-ethers-v5@1.0.10
+
 ## 0.0.11
 
 ### Patch Changes

--- a/examples/ethers-v5/package.json
+++ b/examples/ethers-v5/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers-v5",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers/CHANGELOG.md
+++ b/examples/ethers/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @example/ethers
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+- Updated dependencies [a964d5d]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3@1.17.0
+  - @ant-design/web3-assets@1.11.1
+  - @ant-design/web3-ethers@1.1.9
+
 ## 0.0.11
 
 ### Patch Changes

--- a/examples/ethers/package.json
+++ b/examples/ethers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3-assets
 
+## 1.11.1
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+- Updated dependencies [0ad5d1e]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-icons@1.9.0
+
 ## 1.11.0
 
 ### Minor Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-assets",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/bitcoin/CHANGELOG.md
+++ b/packages/bitcoin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3-bitcoin
 
+## 1.4.4
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+- Updated dependencies [0ad5d1e]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-icons@1.9.0
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-bitcoin",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ant-design/web3-common
 
+## 1.14.0
+
+### Minor Changes
+
+- c32f8e2: feat: support useWalletConnectOfficialModal for wagmi provider and add customQrCodePanel for wallet
+- 613b265: feat: add addresses when multi address connected in onConnected
+
 ## 1.13.0
 
 ### Minor Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-common",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/eth-web3js/CHANGELOG.md
+++ b/packages/eth-web3js/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3-eth-web3js
 
+## 1.1.9
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-wagmi@2.9.0
+  - @ant-design/web3-assets@1.11.1
+
 ## 1.1.8
 
 ### Patch Changes

--- a/packages/eth-web3js/package.json
+++ b/packages/eth-web3js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-eth-web3js",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers-v5/CHANGELOG.md
+++ b/packages/ethers-v5/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ant-design/web3-ethers-v5
 
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-wagmi@2.9.0
+  - @ant-design/web3-assets@1.11.1
+  - @ant-design/web3-ethers@1.1.9
+
 ## 1.0.9
 
 ### Patch Changes

--- a/packages/ethers-v5/package.json
+++ b/packages/ethers-v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers-v5",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3-ethers
 
+## 1.1.9
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-wagmi@2.9.0
+  - @ant-design/web3-assets@1.11.1
+
 ## 1.1.8
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-icons
 
+## 1.9.0
+
+### Minor Changes
+
+- 0ad5d1e: feat: add acala-circle-colorful and conflux-circle-colorful icons
+
 ## 1.8.1
 
 ### Patch Changes

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-icons",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-solana
 
+## 1.1.12
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-assets@1.11.1
+
 ## 1.1.11
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-solana",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/sui/CHANGELOG.md
+++ b/packages/sui/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-sui
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-assets@1.11.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/sui/package.json
+++ b/packages/sui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-sui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/ton/CHANGELOG.md
+++ b/packages/ton/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3-ton
 
+## 1.0.4
+
+### Patch Changes
+
+- 91801ad: chore: add readme
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-assets@1.11.1
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ton",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/wagmi/CHANGELOG.md
+++ b/packages/wagmi/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ant-design/web3-wagmi
 
+## 2.9.0
+
+### Minor Changes
+
+- c32f8e2: feat: support useWalletConnectOfficialModal for wagmi provider and add customQrCodePanel for wallet
+- 613b265: feat: add addresses when multi address connected in onConnected
+
+### Patch Changes
+
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-assets@1.11.1
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-wagmi",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @ant-design/web3
 
+## 1.17.0
+
+### Minor Changes
+
+- c32f8e2: feat: support useWalletConnectOfficialModal for wagmi provider and add customQrCodePanel for wallet
+
+### Patch Changes
+
+- a964d5d: fix: remove useless margin in quick connect mode button
+- Updated dependencies [c32f8e2]
+- Updated dependencies [613b265]
+- Updated dependencies [0ad5d1e]
+  - @ant-design/web3-common@1.14.0
+  - @ant-design/web3-icons@1.9.0
+  - @ant-design/web3-assets@1.11.1
+
 ## 1.16.3
 
 ### Patch Changes

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "1.16.3",
+  "version": "1.17.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
🦋  success packages published successfully:
🦋  @ant-design/web3-assets@1.11.1
🦋  @ant-design/web3-bitcoin@1.4.4
🦋  @ant-design/web3-common@1.14.0
🦋  @ant-design/web3-eth-web3js@1.1.9
🦋  @ant-design/web3-ethers@1.1.9
🦋  @ant-design/web3-ethers-v5@1.0.10
🦋  @ant-design/web3-icons@1.9.0
🦋  @ant-design/web3-solana@1.1.12
🦋  @ant-design/web3-sui@1.0.2
🦋  @ant-design/web3-ton@1.0.4
🦋  @ant-design/web3-wagmi@2.9.0
🦋  @ant-design/web3@1.17.0