### PR TITLE
docs: ✏️ 添加"rc-input"配置，解决antd版本升级问题

### DIFF
--- a/docs/course/dev-init.md
+++ b/docs/course/dev-init.md
@@ -69,7 +69,7 @@ After the installation is complete, you need configure the `next.config.js` beca
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-+ transpilePackages: [  "@ant-design", "antd", "rc-util", "rc-pagination", "rc-picker" ],
++ transpilePackages: [  "@ant-design", "antd", "rc-util", "rc-pagination", "rc-picker", "rc-input" ],
 }
 
 module.exports = nextConfig

--- a/docs/course/dev-init.zh-CN.md
+++ b/docs/course/dev-init.zh-CN.md
@@ -69,7 +69,7 @@ npm i antd @ant-design/web3 --save
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-+ transpilePackages: [  "@ant-design", "antd", "rc-util", "rc-pagination", "rc-picker" ],
++ transpilePackages: [  "@ant-design", "antd", "rc-util", "rc-pagination", "rc-picker", "rc-input" ],
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
由于antd版本升级，rc-input包也需要添加转译配置

✅ Closes: #1241

## 💡 Background and solution
1.  docs: ✏️ 添加"rc-input"配置，解决antd版本升级问题
     由于antd版本升级，rc-input包也需要添加转译配置
2. 根据文档示例启动项目失败，原因是antd升级，transpilePackages 需要额外配置"rc-input"
<!--
1. Git Commit Message Convention: This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
2. Describe the problem and the scenario.
-->

## 🔗 Related issue link
https://github.com/ant-design/ant-design-web3/issues/1241
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
