### PR TITLE
site(solana): switch the recommend Solana RPC provider

### DIFF
--- a/packages/web3/src/solana/demos/recommend.tsx
+++ b/packages/web3/src/solana/demos/recommend.tsx
@@ -7,11 +7,14 @@ import {
   WalletConnectWallet,
 } from '@ant-design/web3-solana';
 
+const rpcProvider = () => `https://api.zan.top/node/v1/solana/mainnet/${YOUR_ZAN_API_KEY}`;
+
 const App: React.FC = () => {
   return (
     <SolanaWeb3ConfigProvider
       autoAddRegisteredWallets
       balance
+      rpcProvider={rpcProvider}
       wallets={[PhantomWallet(), OKXWallet(), WalletConnectWallet()]}
       walletConnect={{ projectId: YOUR_WALLET_CONNECT_PROJECT_ID }}
     >

--- a/packages/web3/src/solana/index.md
+++ b/packages/web3/src/solana/index.md
@@ -23,6 +23,7 @@ The recommended configuration mainly includes:
 - Adds Phantom and OKX wallets by default, providing download guidance if the user has not installed a wallet.
 - Configure `quickConnect` to provide quick connection entry to simplify user operations.
 - Uses `simple` mode and disable group to simplify the interface.
+- Uses a custom RPC provider to provide a better node connection experience.
 
 ## Basic Usage
 

--- a/packages/web3/src/solana/index.zh-CN.md
+++ b/packages/web3/src/solana/index.zh-CN.md
@@ -24,6 +24,7 @@ Ant Design Web3 官方提供了 `@ant-design/web3-solana` 来适配 Solana，它
 - 默认添加 Phantom、OKX 钱包，在用户未安装钱包情况下提供下载引导。
 - 配置 `quickConnect`，提供快速连接入口，简化用户操作。
 - 使用 `simple` 模式，去掉钱包分组，简化界面。
+- 使用自定义的 RPC 提供商，提供更好的节点连接体验。
 
 ## 基本使用
 


### PR DESCRIPTION
The default RPC was called too many times to be used.
默认的 RPC 调用次数太多而无法使用了。

## 💡 Background and solution

fix: #1244 

## 🔗 Related issue link
