### PR TITLE
docs: fix antd web3 style in ssr mode

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -42,6 +42,7 @@ const alias = pkgList.reduce(
         // `useConfig` must be used within `WagmiProvider`. Docs: https://wagmi.sh/react/api/WagmiProvider.html Version: wagmi@2.12.13
         wagmi: resolve('./node_modules/wagmi'),
         '@tanstack/react-query': resolve('./node_modules/@tanstack/react-query'),
+        '@ant-design/cssinjs': resolve('./node_modules/@ant-design/cssinjs'),
       }
     : {}) as Record<string, string>,
 );


### PR DESCRIPTION
修复 SSR 渲染的 HTML 中 antd web3 样式丢失的问题：
<img width="1594" alt="image" src="https://github.com/user-attachments/assets/f4bd67f3-bd42-4f61-b2e4-f7b12085f0be">

原因：使用 18.3.0-canary-c3048aab4-20240326 版本的 react 导致，antd web3 和 dumi 的 @ant-design/cssinjs 版本不一致，使得 StyleProvider 不一致导致样式的 cache 配置不生效，需要手动通过 alias 指定一下版本。

修复后：

<img width="1793" alt="image" src="https://github.com/user-attachments/assets/1e0700e1-86d2-4148-8a16-bf17ec17df1f">


