### PR TITLE
fix(solana): Some wallets cannot connect again

### DIFF
--- a/.changeset/hip-vans-laugh.md
+++ b/.changeset/hip-vans-laugh.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3-solana': patch
+---
+
+fix(solana): Some wallets cannot connect again

--- a/packages/solana/src/solana-provider/__tests__/connect-error.test.tsx
+++ b/packages/solana/src/solana-provider/__tests__/connect-error.test.tsx
@@ -77,7 +77,7 @@ vi.mock('@solana/wallet-adapter-react', async () => {
         mockThrowWalletConnectionError();
         onError?.(new WalletConnectionError('mock error'));
       }
-    }, [mockThrowError, onError]);
+    }, [mockThrowError]);
     return <>{children}</>;
   };
 

--- a/packages/solana/src/solana-provider/config-provider.tsx
+++ b/packages/solana/src/solana-provider/config-provider.tsx
@@ -34,6 +34,8 @@ export interface AntDesignWeb3ConfigProviderProps {
 export const AntDesignWeb3ConfigProvider: React.FC<
   React.PropsWithChildren<AntDesignWeb3ConfigProviderProps>
 > = (props) => {
+  const mountRef = useRef(false);
+
   const {
     publicKey,
     connected,
@@ -45,7 +47,6 @@ export const AntDesignWeb3ConfigProvider: React.FC<
   } = useWallet();
 
   const { connection } = useConnection();
-
   const connectAsyncRef = useRef<ConnectAsync>();
 
   const [balanceData, setBalanceData] = useState<bigint>();
@@ -98,6 +99,11 @@ export const AntDesignWeb3ConfigProvider: React.FC<
 
   // connect/disconnect wallet
   useEffect(() => {
+    // 初始化时跳过，避免与 WalletProvider 的自动连接逻辑冲突
+    if (!mountRef.current) {
+      return;
+    }
+
     if (wallet?.adapter?.name) {
       // if wallet is not ready, need clear selected wallet
       if (!hasWalletReady(wallet.adapter.readyState)) {
@@ -112,6 +118,12 @@ export const AntDesignWeb3ConfigProvider: React.FC<
       }
     }
   }, [wallet?.adapter?.name, connected]);
+
+  useEffect(() => {
+    if (!mountRef.current) {
+      mountRef.current = true;
+    }
+  }, []);
 
   const chainList = useMemo(() => {
     return props.availableChains

--- a/packages/solana/src/solana-provider/config-provider.tsx
+++ b/packages/solana/src/solana-provider/config-provider.tsx
@@ -99,7 +99,7 @@ export const AntDesignWeb3ConfigProvider: React.FC<
 
   // connect/disconnect wallet
   useEffect(() => {
-    // 初始化时跳过，避免与 WalletProvider 的自动连接逻辑冲突
+    // 初始化时跳过，避免与 wallet-adapter 的自动连接逻辑冲突
     if (!mountRef.current) {
       return;
     }


### PR DESCRIPTION
修复某些钱包连接过 dapp 后，刷新页面后再次尝试连接，一直处于 pending 状态的问题。
（目前只在 backpack 发现这种现象）
检查发现是由于与底层库的自动重连逻辑有状态冲突导致。

## 💡 Background and solution

## 🔗 Related issue link
