### PR TITLE
docs: 添加怀旧风格的样式自定义示例

### DIFF
--- a/.changeset/spotty-days-end.md
+++ b/.changeset/spotty-days-end.md
@@ -1,0 +1,5 @@
+---
+'@ant-design/web3': patch
+---
+
+fix: design token for custom style

--- a/.dumi/components/ShowCase/Connect.tsx
+++ b/.dumi/components/ShowCase/Connect.tsx
@@ -1,10 +1,6 @@
 import { ConnectModal, type Wallet } from '@ant-design/web3';
-import {
-  metadata_CoinbaseWallet,
-  metadata_MetaMask,
-  metadata_WalletConnect,
-} from '@ant-design/web3-assets';
-import { ConfigProvider, theme } from 'antd';
+import { metadata_MetaMask, metadata_WalletConnect } from '@ant-design/web3-assets';
+import { Card, ConfigProvider, theme } from 'antd';
 import classNames from 'classnames';
 import { usePrefersColor } from 'dumi';
 
@@ -40,7 +36,14 @@ export default () => {
     >
       <div className={classNames(styles.cardBg, styles.connectModalCardBg)}>
         <h3 className={styles.title}>Connect Modal</h3>
-        <div className={classNames(styles.connectContainer, styles.connectModalContainer)}>
+        <Card
+          style={{ width: 400 }}
+          styles={{
+            body: {
+              padding: 0,
+            },
+          }}
+        >
           <ConnectModal.ModalPanel
             locale={{
               guideTipTitle: 'New to Web3?',
@@ -50,7 +53,7 @@ export default () => {
             footer="Powered by AntChain"
             walletList={walletList}
           />
-        </div>
+        </Card>
       </div>
     </ConfigProvider>
   );

--- a/.dumi/components/ShowCase/index.module.less
+++ b/.dumi/components/ShowCase/index.module.less
@@ -52,15 +52,6 @@
       display: flex;
       justify-content: center;
     }
-
-    .connectContainer {
-      border-radius: 24px;
-      background-color: #fff;
-    }
-    .connectModalCardBg {
-      flex-shrink: 0;
-      width: 400px;
-    }
   }
 }
 

--- a/.dumi/components/Theme/components/Thumbnail.module.less
+++ b/.dumi/components/Theme/components/Thumbnail.module.less
@@ -6,6 +6,7 @@
   height: 100%;
   overflow-x: auto;
   padding: 0 20px;
+  box-sizing: border-box;
   .thumbnailItem {
     cursor: pointer;
     margin-inline-end: 24px;

--- a/.dumi/components/Theme/components/Thumbnail.tsx
+++ b/.dumi/components/Theme/components/Thumbnail.tsx
@@ -7,7 +7,7 @@ import { ThemeContext } from '../../ThemeContext';
 import styles from './Thumbnail.module.less';
 import { themeList, ThemeSetting } from './tokens';
 
-export type ThemeType = 'default' | 'dark' | 'green' | 'pink' | 'violet';
+export type ThemeType = 'default' | 'dark' | 'retro' | 'green' | 'pink' | 'violet';
 
 export type ThemeItem = {
   /**

--- a/.dumi/components/Theme/components/tokens.ts
+++ b/.dumi/components/Theme/components/tokens.ts
@@ -1,9 +1,10 @@
-import type { ThemeConfig } from 'antd';
+import React from 'react';
+import type { Web3ThemeConfig } from '@ant-design/web3';
 import { theme } from 'antd';
 
-export type ThemeValue = 'default' | 'violet' | 'dark' | 'green' | 'pink';
+export type ThemeValue = 'default' | 'retro' | 'violet' | 'dark' | 'green' | 'pink';
 
-export const customToken: ThemeConfig = {
+export const customToken: Web3ThemeConfig = {
   token: {
     borderRadius: 16,
     wireframe: false,
@@ -64,7 +65,8 @@ export type ThemeSetting = {
   color: string;
   value: ThemeValue;
   name: string;
-  token: ThemeConfig;
+  token: Web3ThemeConfig;
+  style?: React.CSSProperties;
 };
 
 // 部分参考 antd 官网的主题 https://github.com/ant-design/ant-design/blob/master/.dumi/pages/index/components/Theme/index.tsx#L305
@@ -98,6 +100,36 @@ export const themeList: ThemeSetting[] = [
       algorithm: theme.darkAlgorithm,
     },
   },
+  // 需要设计师那边给一下配套的整个网站对应的风格图片配置到 Thumbnail.tsx 里面，先不放开
+  // {
+  //   color: '#796d6f',
+  //   value: 'retro',
+  //   name: 'Retro',
+  //   style: {
+  //     boxShadow: '-10px 10px 0px #000000,inset 0 0 0 2px #000000',
+  //     border: 'none',
+  //   },
+  //   token: {
+  //     token: {
+  //       colorPrimary: '#000000',
+  //       colorLink: '#8b837d',
+  //       colorBgContainer: '#eadcd1',
+  //     },
+  //     components: {
+  //       Button: {
+  //         defaultShadow: '-4px 4px 0px #000000,inset 0 0 0 2px #000000',
+  //         defaultHoverBg: '#f3eae4',
+  //         defaultBorderColor: '#000000',
+  //         defaultBg: '#fff',
+  //       },
+  //     },
+  //     web3Components: {
+  //       ConnectModal: {
+  //         hoverWalletBg: '#f3eae4',
+  //       },
+  //     },
+  //   },
+  // },
   {
     value: 'green',
     name: 'Forest green',

--- a/.dumi/components/Theme/index.tsx
+++ b/.dumi/components/Theme/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from 'react';
-import { ConnectModal, type Wallet } from '@ant-design/web3';
+import { ConnectModal, Web3ConfigProvider, type Wallet } from '@ant-design/web3';
 import {
   metadata_CoinbaseWallet,
   metadata_MetaMask,
@@ -7,7 +7,7 @@ import {
   metadata_TokenPocket,
   metadata_WalletConnect,
 } from '@ant-design/web3-assets';
-import { Card, ConfigProvider, theme } from 'antd';
+import { Card, theme } from 'antd';
 import { useTheme } from 'antd-style';
 import { useIntl, usePrefersColor } from 'dumi';
 
@@ -94,7 +94,7 @@ export const Theme: React.FC = () => {
       <div className={styles.desc}>
         {intl.formatMessage({ id: 'app.docs.site.theme.description' })}
       </div>
-      <ConfigProvider
+      <Web3ConfigProvider
         theme={{
           algorithm: isDark ? theme.darkAlgorithm : undefined,
           token:
@@ -107,6 +107,7 @@ export const Theme: React.FC = () => {
       >
         <Card
           className={styles.card}
+          style={curTheme.style}
           styles={{
             body: {
               padding: 0,
@@ -115,7 +116,7 @@ export const Theme: React.FC = () => {
         >
           <ConnectModal.ModalPanel walletList={walletList} />
         </Card>
-      </ConfigProvider>
+      </Web3ConfigProvider>
       <div className={styles.thumbnailBox}>
         <Thumbnail selectedTheme={curTheme} onSelect={(theme) => updateTheme(theme)} />
       </div>

--- a/docs/guide/demos/custom-token-web3.tsx
+++ b/docs/guide/demos/custom-token-web3.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ConnectModal, Web3ConfigProvider, type Wallet } from '@ant-design/web3';
 import { metadata_MetaMask, metadata_WalletConnect } from '@ant-design/web3-assets';
-import { Card, ConfigProvider, Space } from 'antd';
+import { Card, Space } from 'antd';
 
 const App: React.FC = () => {
   const walletList: Wallet[] = [
@@ -29,22 +29,32 @@ const App: React.FC = () => {
   return (
     <Web3ConfigProvider
       theme={{
-        web3Components: {
-          ConnectModal: {
-            walletGroupTextColor: 'red',
-            descriptionColor: 'blue',
-          },
+        token: {
+          colorPrimary: '#000000',
+          colorLink: '#8b837d',
+          colorBgContainer: '#eadcd1',
         },
         components: {
           Button: {
-            borderRadius: 20,
-            borderRadiusLG: 24,
+            defaultShadow: '-4px 4px 0px #000000,inset 0 0 0 2px #000000',
+            defaultHoverBg: '#f3eae4',
+            defaultBorderColor: '#000000',
+            defaultBg: '#fff',
+          },
+        },
+        web3Components: {
+          ConnectModal: {
+            hoverWalletBg: '#f3eae4',
           },
         },
       }}
     >
       <Space>
         <Card
+          style={{
+            boxShadow: '-10px 10px 0px #000000,inset 0 0 0 2px #000000',
+            border: 'none',
+          }}
           styles={{
             body: {
               padding: 0,

--- a/docs/guide/demos/tokens.ts
+++ b/docs/guide/demos/tokens.ts
@@ -108,19 +108,18 @@ export const themeList: ThemeSetting[] = [
       token: {
         colorPrimary: '#000000',
         colorLink: '#8b837d',
+        colorBgContainer: '#f3eae4',
       },
       components: {
         Button: {
           defaultShadow: '-4px 4px 0px #000000,inset 0 0 0 2px #000000',
           defaultHoverBg: '#f3eae4',
+          defaultBg: '#fff',
           defaultBorderColor: '#000000',
         },
         Modal: {
           boxShadow: '-10px 10px 0px #000000,inset 0 0 0 2px #000000',
           contentBg: '#eadcd1',
-        },
-        QRCode: {
-          colorBgContainer: '#f3eae4',
         },
       },
       web3Components: {

--- a/docs/guide/demos/tokens.ts
+++ b/docs/guide/demos/tokens.ts
@@ -1,9 +1,9 @@
-import type { ThemeConfig } from 'antd';
+import type { Web3ThemeConfig } from '@ant-design/web3';
 import { theme } from 'antd';
 
-export type ThemeValue = 'default' | 'violet' | 'dark' | 'green' | 'pink';
+export type ThemeValue = 'default' | 'violet' | 'dark' | 'green' | 'pink' | 'retro';
 
-export const customToken: ThemeConfig = {
+export const customToken: Web3ThemeConfig = {
   token: {
     borderRadius: 16,
     wireframe: false,
@@ -64,7 +64,8 @@ export type ThemeSetting = {
   color: string;
   value: ThemeValue;
   name: string;
-  token: ThemeConfig;
+  token: Web3ThemeConfig;
+  buttonType?: 'primary' | 'dashed' | 'link' | 'text' | 'default';
 };
 
 // 部分参考 antd 官网的主题 https://github.com/ant-design/ant-design/blob/master/.dumi/pages/index/components/Theme/index.tsx#L305
@@ -96,6 +97,37 @@ export const themeList: ThemeSetting[] = [
         },
       },
       algorithm: theme.darkAlgorithm,
+    },
+  },
+  {
+    color: '#796d6f',
+    value: 'retro',
+    name: 'Retro',
+    buttonType: 'default',
+    token: {
+      token: {
+        colorPrimary: '#000000',
+        colorLink: '#8b837d',
+      },
+      components: {
+        Button: {
+          defaultShadow: '-4px 4px 0px #000000,inset 0 0 0 2px #000000',
+          defaultHoverBg: '#f3eae4',
+          defaultBorderColor: '#000000',
+        },
+        Modal: {
+          boxShadow: '-10px 10px 0px #000000,inset 0 0 0 2px #000000',
+          contentBg: '#eadcd1',
+        },
+        QRCode: {
+          colorBgContainer: '#f3eae4',
+        },
+      },
+      web3Components: {
+        ConnectModal: {
+          hoverWalletBg: '#f3eae4',
+        },
+      },
     },
   },
   {

--- a/docs/guide/demos/try-it-out/bitcoin.tsx
+++ b/docs/guide/demos/try-it-out/bitcoin.tsx
@@ -15,9 +15,10 @@ interface Props {
   mode: ConnectModalProps['mode'];
   size: SizeType;
   quickConnect: boolean;
+  buttonType: 'primary' | 'dashed' | 'link' | 'text' | 'default';
 }
 
-const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
+const App: React.FC<Props> = ({ mode, size, quickConnect, buttonType }) => {
   return (
     <BitcoinWeb3ConfigProvider autoConnect wallets={[XverseWallet(), UnisatWallet(), OkxWallet()]}>
       <Connector
@@ -26,7 +27,7 @@ const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
         }}
       >
         <ConnectButton
-          type="primary"
+          type={buttonType}
           style={{
             width: 'auto',
           }}

--- a/docs/guide/demos/try-it-out/ethereum.tsx
+++ b/docs/guide/demos/try-it-out/ethereum.tsx
@@ -16,9 +16,10 @@ interface Props {
   mode: ConnectModalProps['mode'];
   size: SizeType;
   quickConnect: boolean;
+  buttonType: 'primary' | 'dashed' | 'link' | 'text' | 'default';
 }
 
-const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
+const App: React.FC<Props> = ({ mode, size, quickConnect, buttonType }) => {
   return (
     <WagmiWeb3ConfigProvider
       eip6963={{
@@ -43,7 +44,7 @@ const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
         }}
       >
         <ConnectButton
-          type="primary"
+          type={buttonType}
           style={{
             width: 'auto',
           }}

--- a/docs/guide/demos/try-it-out/index.tsx
+++ b/docs/guide/demos/try-it-out/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Web3ConfigProvider } from '@ant-design/web3';
 import type { ConnectModalProps } from '@ant-design/web3';
 import { TinyColor } from '@ctrl/tinycolor';
-import { Col, ConfigProvider, Radio, Row, Select, Slider, Space, Switch, Tabs } from 'antd';
+import { Col, Radio, Row, Select, Slider, Space, Switch, Tabs } from 'antd';
 import type { ConfigProviderProps } from 'antd';
 
 import { themeList } from '../tokens';
@@ -49,9 +50,11 @@ const App: React.FC = () => {
   const [radius, setRadius] = React.useState<number>(defaultRadius);
   const currentTheme = themeList.find((t) => t.value === theme);
 
+  const buttonType = currentTheme?.buttonType || 'primary';
+
   return (
     <>
-      <ConfigProvider
+      <Web3ConfigProvider
         theme={{
           ...currentTheme?.token,
           token: {
@@ -69,7 +72,12 @@ const App: React.FC = () => {
               key: 'ethereum',
               children: (
                 <div className={styles.connectorContainer}>
-                  <EthereumApp mode={mode} quickConnect={quickConnect} size={size} />
+                  <EthereumApp
+                    mode={mode}
+                    quickConnect={quickConnect}
+                    size={size}
+                    buttonType={buttonType}
+                  />
                 </div>
               ),
             },
@@ -78,7 +86,12 @@ const App: React.FC = () => {
               key: 'bitcoin',
               children: (
                 <div className={styles.connectorContainer}>
-                  <BitcoinApp mode={mode} quickConnect={quickConnect} size={size} />
+                  <BitcoinApp
+                    mode={mode}
+                    quickConnect={quickConnect}
+                    size={size}
+                    buttonType={buttonType}
+                  />
                 </div>
               ),
             },
@@ -87,7 +100,12 @@ const App: React.FC = () => {
               key: 'solana',
               children: (
                 <div className={styles.connectorContainer}>
-                  <SolanaApp mode={mode} quickConnect={quickConnect} size={size} />
+                  <SolanaApp
+                    mode={mode}
+                    quickConnect={quickConnect}
+                    size={size}
+                    buttonType={buttonType}
+                  />
                 </div>
               ),
             },
@@ -96,7 +114,12 @@ const App: React.FC = () => {
               key: 'sui',
               children: (
                 <div className={styles.connectorContainer}>
-                  <SuiApp mode={mode} quickConnect={quickConnect} size={size} />
+                  <SuiApp
+                    mode={mode}
+                    quickConnect={quickConnect}
+                    size={size}
+                    buttonType={buttonType}
+                  />
                 </div>
               ),
             },
@@ -105,13 +128,18 @@ const App: React.FC = () => {
               key: 'ton',
               children: (
                 <div className={styles.connectorContainer}>
-                  <TonApp mode={mode} quickConnect={quickConnect} size={size} />
+                  <TonApp
+                    mode={mode}
+                    quickConnect={quickConnect}
+                    size={size}
+                    buttonType={buttonType}
+                  />
                 </div>
               ),
             },
           ]}
         />
-      </ConfigProvider>
+      </Web3ConfigProvider>
       <div className={styles.configContainer}>
         <Row>
           <Col xs={24} sm={12}>

--- a/docs/guide/demos/try-it-out/solana.tsx
+++ b/docs/guide/demos/try-it-out/solana.tsx
@@ -10,9 +10,10 @@ interface Props {
   mode: ConnectModalProps['mode'];
   size: SizeType;
   quickConnect: boolean;
+  buttonType: 'primary' | 'dashed' | 'link' | 'text' | 'default';
 }
 
-const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
+const App: React.FC<Props> = ({ mode, size, quickConnect, buttonType }) => {
   return (
     <SolanaWeb3ConfigProvider wallets={[CoinbaseWallet(), PhantomWallet()]}>
       <Connector
@@ -21,7 +22,7 @@ const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
         }}
       >
         <ConnectButton
-          type="primary"
+          type={buttonType}
           style={{
             width: 'auto',
           }}

--- a/docs/guide/demos/try-it-out/sui.tsx
+++ b/docs/guide/demos/try-it-out/sui.tsx
@@ -10,9 +10,10 @@ interface Props {
   mode: ConnectModalProps['mode'];
   size: SizeType;
   quickConnect: boolean;
+  buttonType: 'primary' | 'dashed' | 'link' | 'text' | 'default';
 }
 
-const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
+const App: React.FC<Props> = ({ mode, size, quickConnect, buttonType }) => {
   return (
     <SuiWeb3ConfigProvider balance autoConnect wallets={[Suiet(), SuiWallet()]}>
       <Connector
@@ -21,7 +22,7 @@ const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
         }}
       >
         <ConnectButton
-          type="primary"
+          type={buttonType}
           style={{
             width: 'auto',
           }}

--- a/docs/guide/demos/try-it-out/ton.tsx
+++ b/docs/guide/demos/try-it-out/ton.tsx
@@ -10,9 +10,10 @@ interface Props {
   mode: ConnectModalProps['mode'];
   size: SizeType;
   quickConnect: boolean;
+  buttonType: 'primary' | 'dashed' | 'link' | 'text' | 'default';
 }
 
-const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
+const App: React.FC<Props> = ({ mode, size, quickConnect, buttonType }) => {
   return (
     <TonWeb3ConfigProvider wallets={[tonkeeper, okxTonWallet, { key: 'safepalwallet' }]}>
       <Connector
@@ -21,7 +22,7 @@ const App: React.FC<Props> = ({ mode, size, quickConnect }) => {
         }}
       >
         <ConnectButton
-          type="primary"
+          type={buttonType}
           style={{
             width: 'auto',
           }}

--- a/docs/guide/theme.md
+++ b/docs/guide/theme.md
@@ -25,6 +25,6 @@ We provide a [theme editor](/theme-editor-cn) where you can modify Design Tokens
 
 ### Customize More Design Tokens for Ant Design Web3
 
-In addition to Ant Design's Design Tokens, Ant Design Web3 also offers some additional Design Tokens that you can customize. The Design Tokens for components are continuously being supplemented, and you can view the supported Design Tokens on the corresponding component documentation pages. If you find any unsupported or incorrectly used Design Tokens, please [submit an issue](https://github.com/ant-design/ant-design-web3/issues) to let us know.
+In addition to Ant Design's Design Tokens, Ant Design Web3 also offers some additional Design Tokens that you can customize. The Design Tokens for components are continuously being supplemented, and you can view the supported Design Tokens on the corresponding component documentation pages. If you find any unsupported or incorrectly used Design Tokens, please [submit an issue](https://github.com/ant-design/ant-design-web3/issues) to let us know. Below is a specific example, you can customize the Design Tokens of Ant Design and Ant Design Web3 to achieve flexible custom styles. More examples can be viewed by visiting [Try It Out](/guide/ant-design-web3-cn#try-it-out).
 
 <code src="./demos/custom-token-web3.tsx"></code>

--- a/docs/guide/theme.zh-CN.md
+++ b/docs/guide/theme.zh-CN.md
@@ -25,6 +25,6 @@ Ant Design Web3 内置了对暗黑模式的支持，继承自 Ant Design 的配�
 
 ### 自定义更多 Ant Design Web3 的 Design Token
 
-除了 Ant Design 的 Design Token，Ant Design Web3 还提供了一些额外的 Design Token，你也可以自定义这些 Design Token。组件的 Design Token 在持续的补充中，你可以在对应的组件文档页面查看支持的 Design Token。如果你发现不支持或者使用有误的 Design Token，请[提交 issue](https://github.com/ant-design/ant-design-web3/issues) 告诉我们。
+除了 Ant Design 的 Design Token，Ant Design Web3 还提供了一些额外的 Design Token，你也可以自定义这些 Design Token。组件的 Design Token 在持续的补充中，你可以在对应的组件文档页面查看支持的 Design Token。如果你发现不支持或者使用有误的 Design Token，请[提交 issue](https://github.com/ant-design/ant-design-web3/issues) 告诉我们。下面是一个具体的示例，你可以通过定义 Ant Design 和 Ant Design Web3 的组件的 Design Token 实现灵活的自定义样式。更多的示例你可以通过访问[试试看](/guide/ant-design-web3-cn#试试看)查看。
 
 <code src="./demos/custom-token-web3.tsx"></code>

--- a/packages/web3/src/connect-modal/style/index.tsx
+++ b/packages/web3/src/connect-modal/style/index.tsx
@@ -50,13 +50,11 @@ const resetStyle = (token: ConnectModalToken): CSSInterpolation => {
 
 const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
   const { web3ComponentsCls: componentCls } = token;
+
   return [
     {
       [`${componentCls}`]: {
         paddingBlockEnd: 0,
-        '.ant-modal-content': {
-          background: token.colorBgContainer,
-        },
       },
 
       [`${componentCls}-body`]: {
@@ -186,18 +184,21 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
                         [`${componentCls}-plugin-tag:not(:disabled)`]: {
                           color: token.colorPrimaryTextHover,
                           borderColor: token.colorPrimaryTextHover,
+                          background: token.Button?.defaultHoverBg,
                         },
                       },
                       [`&:not(:has(${componentCls}-plugin-tag))`]: {
                         [`${componentCls}-qr-btn`]: {
                           color: token.colorPrimaryTextHover,
                           borderColor: token.colorPrimaryTextHover,
+                          background: token.Button?.defaultHoverBg,
                         },
                       },
                       [`&:has(${componentCls}-plugin-tag:disabled)`]: {
                         [`${componentCls}-qr-btn`]: {
                           color: token.colorPrimaryTextHover,
                           borderColor: token.colorPrimaryTextHover,
+                          background: token.Button?.defaultHoverBg,
                         },
                       },
                     },
@@ -223,9 +224,11 @@ const getThemeStyle = (token: ConnectModalToken): CSSInterpolation => {
               left: '50%',
               transform: 'translateX(-50%)',
               height: token.controlHeightLG,
-              backgroundImage: `linear-gradient(to bottom, ${new TinyColor(token.colorBgContainer)
+              backgroundImage: `linear-gradient(to bottom, ${new TinyColor(
+                token.Modal?.contentBg || token.colorBgContainer,
+              )
                 .setAlpha(0)
-                .toRgbString()}, ${new TinyColor(token.colorBgContainer)
+                .toRgbString()}, ${new TinyColor(token.Modal?.contentBg || token.colorBgContainer)
                 .setAlpha(1)
                 .toRgbString()})`,
               pointerEvents: 'none',
@@ -570,12 +573,12 @@ export function useStyle(prefixCls: string): UseStyleResult {
     const isDark = isDarkTheme(token);
     const hoverWalletBg = new TinyColor(isDark ? token.colorWhite : '#000')
       .setAlpha(0.08)
-      .onBackground(token.colorBgContainer)
+      .onBackground(token.Modal?.contentBg || token.colorBgContainer)
       .toRgbString();
 
     const connectModalToken: ConnectModalToken = {
       ...token,
-      selectedWalletColor: token.colorBgContainer,
+      selectedWalletColor: token.Modal?.contentBg || token.colorBgContainer,
       hoverWalletBg,
       selectedWalletBg: hoverWalletBg,
       panelSplitLineColor: new TinyColor(token.colorText).setAlpha(0.06).toRgbString(),

--- a/packages/web3/src/index.ts
+++ b/packages/web3/src/index.ts
@@ -11,5 +11,5 @@ export * from './token-select';
 export * from './hooks';
 export * from '@ant-design/web3-common';
 // export Web3ConfigProvider in ./web3-config-provider for replace the one in @ant-design/web3-common
-export { Web3ConfigProvider } from './web3-config-provider';
+export { Web3ConfigProvider, type Web3ThemeConfig } from './web3-config-provider';
 export * from './pay-panel';

--- a/packages/web3/src/nft-card/style/index.tsx
+++ b/packages/web3/src/nft-card/style/index.tsx
@@ -12,7 +12,7 @@ export interface NFTCardToken extends Web3AliasToken {
   componentCls: string;
 }
 
-const genNFTCardStyle: GenerateStyle<NFTCardToken> = (token) => {
+const genNFTCardStyle: GenerateStyle<NFTCardToken> = (token: NFTCardToken) => {
   const {
     componentCls,
     nftCardWidth,
@@ -41,7 +41,7 @@ const genNFTCardStyle: GenerateStyle<NFTCardToken> = (token) => {
   return {
     [`${componentCls}-container`]: {
       width: nftCardWidth,
-      backgroundColor: colorWhite,
+      backgroundColor: token.colorBgContainer,
       borderRadius: nftCardBorderRadius,
       border: `1px solid ${colorBorder}`,
       overflow: 'hidden',

--- a/packages/web3/src/nft-card/style/index.tsx
+++ b/packages/web3/src/nft-card/style/index.tsx
@@ -12,7 +12,7 @@ export interface NFTCardToken extends Web3AliasToken {
   componentCls: string;
 }
 
-const genNFTCardStyle: GenerateStyle<NFTCardToken> = (token: NFTCardToken) => {
+const genNFTCardStyle: GenerateStyle<NFTCardToken> = (token) => {
   const {
     componentCls,
     nftCardWidth,

--- a/packages/web3/src/web3-config-provider/index.tsx
+++ b/packages/web3/src/web3-config-provider/index.tsx
@@ -2,13 +2,11 @@ import {
   Web3ConfigProvider as AntdWeb3ConfigProvider,
   type Web3ConfigProviderProps,
 } from '@ant-design/web3-common';
-import { ConfigProvider, version, type ThemeConfig } from 'antd';
+import { ConfigProvider, type ThemeConfig } from 'antd';
 
 import { ComponentToken as ConnectModalComponentToken } from '../connect-modal/style/index';
 
-console.log('antd version', version);
-
-export interface Web3ThemeConfig extends ThemeConfig {
+interface Web3ThemeConfig extends ThemeConfig {
   web3Components?: {
     ConnectModal?: Partial<ConnectModalComponentToken>;
   };
@@ -33,4 +31,4 @@ const Web3ConfigProvider: React.FC<{ theme?: Web3ThemeConfig } & Web3ConfigProvi
   );
 };
 
-export { Web3ConfigProvider };
+export { Web3ConfigProvider, Web3ThemeConfig };


### PR DESCRIPTION
添加了一个更复杂的自定义样式，体现出 Ant Design 和 Ant Design Web3 自定义样式的能力：

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/db02588d-21d6-47a9-9590-329902d4940b" />
