### PR TITLE
chore: release 1.22.0

### DIFF
--- a/.changeset/heavy-rice-deliver.md
+++ b/.changeset/heavy-rice-deliver.md
@@ -1,7 +1,0 @@
----
-'@ant-design/web3-assets': minor
-'@ant-design/web3-common': minor
-'@ant-design/web3': minor
----
-
-feat: support UniversalLink for support connect some wallet in mobile

--- a/.changeset/odd-feet-search.md
+++ b/.changeset/odd-feet-search.md
@@ -1,6 +1,0 @@
----
-'@ant-design/web3-solana': minor
-'@ant-design/web3-icons': minor
----
-
-feat: support SolflareWallet

--- a/examples/eth-web3js/CHANGELOG.md
+++ b/examples/eth-web3js/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @example/eth-web3js
 
+## 0.0.20
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+  - @ant-design/web3@1.22.0
+  - @ant-design/web3-eth-web3js@1.1.17
+
 ## 0.0.19
 
 ### Patch Changes

--- a/examples/eth-web3js/package.json
+++ b/examples/eth-web3js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/eth-web3js",
   "private": true,
-  "version": "0.0.19",
+  "version": "0.0.20",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers-v5/CHANGELOG.md
+++ b/examples/ethers-v5/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @example/ethers-v5
 
+## 0.0.20
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+  - @ant-design/web3@1.22.0
+  - @ant-design/web3-ethers-v5@1.0.18
+
 ## 0.0.19
 
 ### Patch Changes

--- a/examples/ethers-v5/package.json
+++ b/examples/ethers-v5/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers-v5",
   "private": true,
-  "version": "0.0.19",
+  "version": "0.0.20",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers/CHANGELOG.md
+++ b/examples/ethers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @example/ethers
 
+## 0.0.20
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+  - @ant-design/web3@1.22.0
+  - @ant-design/web3-ethers@1.1.17
+
 ## 0.0.19
 
 ### Patch Changes

--- a/examples/ethers/package.json
+++ b/examples/ethers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers",
   "private": true,
-  "version": "0.0.19",
+  "version": "0.0.20",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @ant-design/web3-assets
 
+## 1.12.0
+
+### Minor Changes
+
+- b6f1f1d: feat: support UniversalLink for support connect some wallet in mobile
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-common@1.18.0
+  - @ant-design/web3-icons@1.12.0
+
 ## 1.11.8
 
 ### Patch Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-assets",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/bitcoin/CHANGELOG.md
+++ b/packages/bitcoin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-bitcoin
 
+## 1.5.2
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-common@1.18.0
+  - @ant-design/web3-icons@1.12.0
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-bitcoin",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-common
 
+## 1.18.0
+
+### Minor Changes
+
+- b6f1f1d: feat: support UniversalLink for support connect some wallet in mobile
+
 ## 1.17.0
 
 ### Minor Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-common",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/eth-web3js/CHANGELOG.md
+++ b/packages/eth-web3js/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-eth-web3js
 
+## 1.1.17
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+  - @ant-design/web3-wagmi@2.10.2
+
 ## 1.1.16
 
 ### Patch Changes

--- a/packages/eth-web3js/package.json
+++ b/packages/eth-web3js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-eth-web3js",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers-v5/CHANGELOG.md
+++ b/packages/ethers-v5/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3-ethers-v5
 
+## 1.0.18
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+  - @ant-design/web3-ethers@1.1.17
+  - @ant-design/web3-wagmi@2.10.2
+
 ## 1.0.17
 
 ### Patch Changes

--- a/packages/ethers-v5/package.json
+++ b/packages/ethers-v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers-v5",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-ethers
 
+## 1.1.17
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+  - @ant-design/web3-wagmi@2.10.2
+
 ## 1.1.16
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-icons
 
+## 1.12.0
+
+### Minor Changes
+
+- b6f1f1d: feat: support SolflareWallet
+
 ## 1.11.4
 
 ### Patch Changes

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-icons",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ant-design/web3-solana
 
+## 1.3.0
+
+### Minor Changes
+
+- b6f1f1d: feat: support SolflareWallet
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+
 ## 1.2.7
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-solana",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/sui/CHANGELOG.md
+++ b/packages/sui/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ant-design/web3-sui
 
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+
 ## 1.0.9
 
 ### Patch Changes

--- a/packages/sui/package.json
+++ b/packages/sui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-sui",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/ton/CHANGELOG.md
+++ b/packages/ton/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ant-design/web3-ton
 
+## 1.0.12
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+
 ## 1.0.11
 
 ### Patch Changes

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ton",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/wagmi/CHANGELOG.md
+++ b/packages/wagmi/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ant-design/web3-wagmi
 
+## 2.10.2
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+
 ## 2.10.1
 
 ### Patch Changes

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-wagmi",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @ant-design/web3
 
+## 1.22.0
+
+### Minor Changes
+
+- b6f1f1d: feat: support UniversalLink for support connect some wallet in mobile
+
+### Patch Changes
+
+- Updated dependencies [b6f1f1d]
+- Updated dependencies [b6f1f1d]
+  - @ant-design/web3-assets@1.12.0
+  - @ant-design/web3-common@1.18.0
+  - @ant-design/web3-icons@1.12.0
+
 ## 1.21.0
 
 ### Minor Changes

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
🦋  success packages published successfully:
🦋  @ant-design/web3-assets@1.12.0
🦋  @ant-design/web3-bitcoin@1.5.2
🦋  @ant-design/web3-common@1.18.0
🦋  @ant-design/web3-eth-web3js@1.1.17
🦋  @ant-design/web3-ethers@1.1.17
🦋  @ant-design/web3-ethers-v5@1.0.18
🦋  @ant-design/web3-icons@1.12.0
🦋  @ant-design/web3-solana@1.3.0
🦋  @ant-design/web3-sui@1.0.10
🦋  @ant-design/web3-ton@1.0.12
🦋  @ant-design/web3-wagmi@2.10.2
🦋  @ant-design/web3@1.22.0