### PR TITLE
chore: release 1.23.0

### DIFF
--- a/.changeset/chilly-rice-clap.md
+++ b/.changeset/chilly-rice-clap.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3': minor
----
-
-feat: add cropyto-input footer config

--- a/.changeset/fifty-pianos-agree.md
+++ b/.changeset/fifty-pianos-agree.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3-ton': minor
----
-
-feat: update wallet extension info

--- a/.changeset/flat-coats-study.md
+++ b/.changeset/flat-coats-study.md
@@ -1,6 +1,0 @@
----
-'@ant-design/web3-tron': major
-'@ant-design/web3-icons': minor
----
-
-feat: Add support for Tron

--- a/.changeset/hot-parrots-laugh.md
+++ b/.changeset/hot-parrots-laugh.md
@@ -1,6 +1,0 @@
----
-'@ant-design/web3-common': minor
-'@ant-design/web3': minor
----
-
-feat(connect-button): Added wallet address and balance co-display mode

--- a/examples/eth-web3js/CHANGELOG.md
+++ b/examples/eth-web3js/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @example/eth-web3js
 
+## 0.0.21
+
+### Patch Changes
+
+- Updated dependencies [6e33d17]
+- Updated dependencies [0f83657]
+  - @ant-design/web3@1.23.0
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+  - @ant-design/web3-eth-web3js@1.1.18
+
 ## 0.0.20
 
 ### Patch Changes

--- a/examples/eth-web3js/package.json
+++ b/examples/eth-web3js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/eth-web3js",
   "private": true,
-  "version": "0.0.20",
+  "version": "0.0.21",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers-v5/CHANGELOG.md
+++ b/examples/ethers-v5/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @example/ethers-v5
 
+## 0.0.21
+
+### Patch Changes
+
+- Updated dependencies [6e33d17]
+- Updated dependencies [0f83657]
+  - @ant-design/web3@1.23.0
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+  - @ant-design/web3-ethers-v5@1.0.19
+
 ## 0.0.20
 
 ### Patch Changes

--- a/examples/ethers-v5/package.json
+++ b/examples/ethers-v5/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers-v5",
   "private": true,
-  "version": "0.0.20",
+  "version": "0.0.21",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers/CHANGELOG.md
+++ b/examples/ethers/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @example/ethers
 
+## 0.0.21
+
+### Patch Changes
+
+- Updated dependencies [6e33d17]
+- Updated dependencies [0f83657]
+  - @ant-design/web3@1.23.0
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+  - @ant-design/web3-ethers@1.1.18
+
 ## 0.0.20
 
 ### Patch Changes

--- a/examples/ethers/package.json
+++ b/examples/ethers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers",
   "private": true,
-  "version": "0.0.20",
+  "version": "0.0.21",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-assets
 
+## 1.12.1
+
+### Patch Changes
+
+- Updated dependencies [1f08bd4]
+- Updated dependencies [0f83657]
+  - @ant-design/web3-icons@1.13.0
+  - @ant-design/web3-common@1.19.0
+
 ## 1.12.0
 
 ### Minor Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-assets",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/bitcoin/CHANGELOG.md
+++ b/packages/bitcoin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-bitcoin
 
+## 1.5.3
+
+### Patch Changes
+
+- Updated dependencies [1f08bd4]
+- Updated dependencies [0f83657]
+  - @ant-design/web3-icons@1.13.0
+  - @ant-design/web3-common@1.19.0
+
 ## 1.5.2
 
 ### Patch Changes

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-bitcoin",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-common
 
+## 1.19.0
+
+### Minor Changes
+
+- 0f83657: feat(connect-button): Added wallet address and balance co-display mode
+
 ## 1.18.0
 
 ### Minor Changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-common",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/eth-web3js/CHANGELOG.md
+++ b/packages/eth-web3js/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-eth-web3js
 
+## 1.1.18
+
+### Patch Changes
+
+- Updated dependencies [0f83657]
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+  - @ant-design/web3-wagmi@2.10.3
+
 ## 1.1.17
 
 ### Patch Changes

--- a/packages/eth-web3js/package.json
+++ b/packages/eth-web3js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-eth-web3js",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers-v5/CHANGELOG.md
+++ b/packages/ethers-v5/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ant-design/web3-ethers-v5
 
+## 1.0.19
+
+### Patch Changes
+
+- Updated dependencies [0f83657]
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+  - @ant-design/web3-ethers@1.1.18
+  - @ant-design/web3-wagmi@2.10.3
+
 ## 1.0.18
 
 ### Patch Changes

--- a/packages/ethers-v5/package.json
+++ b/packages/ethers-v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers-v5",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ant-design/web3-ethers
 
+## 1.1.18
+
+### Patch Changes
+
+- Updated dependencies [0f83657]
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+  - @ant-design/web3-wagmi@2.10.3
+
 ## 1.1.17
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-icons
 
+## 1.13.0
+
+### Minor Changes
+
+- 1f08bd4: feat: Add support for Tron
+
 ## 1.12.0
 
 ### Minor Changes

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-icons",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ant-design/web3-solana
 
+## 1.3.1
+
+### Patch Changes
+
+- Updated dependencies [0f83657]
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-solana",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/sui/CHANGELOG.md
+++ b/packages/sui/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ant-design/web3-sui
 
+## 1.0.11
+
+### Patch Changes
+
+- Updated dependencies [0f83657]
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+
 ## 1.0.10
 
 ### Patch Changes

--- a/packages/sui/package.json
+++ b/packages/sui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-sui",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/ton/CHANGELOG.md
+++ b/packages/ton/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @ant-design/web3-ton
 
+## 1.1.0
+
+### Minor Changes
+
+- 09565b3: feat: update wallet extension info
+
+### Patch Changes
+
+- Updated dependencies [0f83657]
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+
 ## 1.0.12
 
 ### Patch Changes

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ton",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/tron/CHANGELOG.md
+++ b/packages/tron/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @ant-design/web3-tron
+
+## 1.0.0
+
+### Major Changes
+
+- 1f08bd4: feat: Add support for Tron
+
+### Patch Changes
+
+- Updated dependencies [0f83657]
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1

--- a/packages/tron/package.json
+++ b/packages/tron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-tron",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/wagmi/CHANGELOG.md
+++ b/packages/wagmi/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ant-design/web3-wagmi
 
+## 2.10.3
+
+### Patch Changes
+
+- Updated dependencies [0f83657]
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+
 ## 2.10.2
 
 ### Patch Changes

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-wagmi",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @ant-design/web3
 
+## 1.23.0
+
+### Minor Changes
+
+- 6e33d17: feat: add cropyto-input footer config
+- 0f83657: feat(connect-button): Added wallet address and balance co-display mode
+
+### Patch Changes
+
+- Updated dependencies [1f08bd4]
+- Updated dependencies [0f83657]
+  - @ant-design/web3-icons@1.13.0
+  - @ant-design/web3-common@1.19.0
+  - @ant-design/web3-assets@1.12.1
+
 ## 1.22.0
 
 ### Minor Changes

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
🦋  success packages published successfully:
🦋  @ant-design/web3-assets@1.12.1
🦋  @ant-design/web3-bitcoin@1.5.3
🦋  @ant-design/web3-common@1.19.0
🦋  @ant-design/web3-eth-web3js@1.1.18
🦋  @ant-design/web3-ethers@1.1.18
🦋  @ant-design/web3-ethers-v5@1.0.19
🦋  @ant-design/web3-icons@1.13.0
🦋  @ant-design/web3-solana@1.3.1
🦋  @ant-design/web3-sui@1.0.11
🦋  @ant-design/web3-ton@1.1.0
🦋  @ant-design/web3-tron@1.0.0
🦋  @ant-design/web3-wagmi@2.10.3
🦋  @ant-design/web3@1.23.0