### PR TITLE
docs: Add addressPrefix demo for Address

### DIFF
--- a/packages/web3/src/address/demos/addressPrefix.tsx
+++ b/packages/web3/src/address/demos/addressPrefix.tsx
@@ -1,0 +1,22 @@
+import { Address } from '@ant-design/web3';
+import { Space } from 'antd';
+
+const App: React.FC = () => {
+  return (
+    <Space direction="vertical">
+      <div>
+        Default: <Address address={'3ea2cfd153b8d8505097b81c87c11f5d05097c18'} />
+      </div>
+      <div>
+        Custom:{' '}
+        <Address address={'3ea2cfd153b8d8505097b81c87c11f5d05097c18'} addressPrefix={'0xb1'} />
+      </div>
+      <div>
+        No Prefix:{' '}
+        <Address address={'3ea2cfd153b8d8505097b81c87c11f5d05097c18'} addressPrefix={false} />
+      </div>
+    </Space>
+  );
+};
+
+export default App;

--- a/packages/web3/src/address/index.md
+++ b/packages/web3/src/address/index.md
@@ -25,6 +25,10 @@ coverDark: https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*ymJDSYEjQKwAAA
 
 <code src="./demos/customTooltip.tsx"></code>
 
+## AddressPrefix
+
+<code src="./demos/addressPrefix.tsx"></code>
+
 ## API
 
 | Property | Description | Type | Default | Version |
@@ -32,6 +36,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*ymJDSYEjQKwAAA
 | ellipsis | Address clipping strategy | `boolean \| { headClip?: number, tailClip?: number }` | `{ headClip: 6, tailClip: 4 }` | - |
 | copyable | Address copyable | `boolean` | `false` | - |
 | address | Address | `string` | - | - |
+| addressPrefix | The prefix to use for the address | `boolean \| string` | `0x` | - |
 | tooltip | Show tooltip when hover address | `boolean \|`[Tooltip.title](https://ant.design/components/tooltip-cn#api) | `true ` | - |
 | format | Address format | `boolean \| (input: string) => ReactNode` | `false` | - |
 | locale | Multilingual settings | `Locale["address"]` | - | - |

--- a/packages/web3/src/address/index.zh-CN.md
+++ b/packages/web3/src/address/index.zh-CN.md
@@ -26,6 +26,10 @@ coverDark: https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*ymJDSYEjQKwAAA
 
 <code src="./demos/customTooltip.tsx"></code>
 
+## 地址前缀
+
+<code src="./demos/addressPrefix.tsx"></code>
+
 ## API
 
 | 属性 | 描述 | 类型 | 默认值 | 版本 |
@@ -33,6 +37,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_mutawc/afts/img/A*ymJDSYEjQKwAAA
 | ellipsis | 地址裁剪策略 | `boolean \| { headClip?: number, tailClip?: number }` | `{ headClip: 6, tailClip: 4 }` | - |
 | copyable | 是否可复制 | `boolean` | `false` | - |
 | address | 地址 | `string` | - | - |
+| addressPrefix | 地址前缀 | `boolean \| string` | `0x` | - |
 | tooltip | 鼠标移入地址时展示提示 | `boolean \|` [Tooltip.title](https://ant.design/components/tooltip-cn#api) | `true ` | - |
 | format | 地址格式化 | `boolean \| (input: string) => ReactNode` | `false` | - |
 | locale | 多语言设置 | `Locale["address"]` | - | - |


### PR DESCRIPTION
## 💡 Background and solution

Add addressPrefix demo for Address.

![image](https://github.com/user-attachments/assets/d46b9b0d-9e51-472f-9973-ffffadf2fb1e)

![image](https://github.com/user-attachments/assets/56c82dbf-ac58-4fa3-8c41-d3467f12d339)



