### PR TITLE
ci: update qrcode url

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -34,7 +34,7 @@ jobs:
 
             🎉 感谢您的贡献！如果您还没有加入钉钉社区群，请扫描下方二维码加入我们。
 
-            <img src="https://github.com/ant-design/ant-design-web3/assets/117748716/4427c32b-c73b-4ae2-b7d9-3b0a5142e4ea" alt="Ant Design Web3 Community Group QCcode" height="200" />
+            <img src="https://github.com/user-attachments/assets/73b3a956-f539-4316-b203-8f38f8c73a5e" alt="Ant Design Web3 Community Group QCcode" height="200" />
 
             <!-- WELCOME_CONTRIBUTION -->
           body-include: '<!-- WELCOME_CONTRIBUTION -->'


### PR DESCRIPTION
原来的邀请二维码过期了，换个新的
![image](https://github.com/user-attachments/assets/073a9c35-ee97-426c-82c6-f256d899376d)
