### PR TITLE
chore: Release @ant-design/icons 1.15.0

### DIFF
--- a/.changeset/soft-facts-shine.md
+++ b/.changeset/soft-facts-shine.md
@@ -1,5 +1,0 @@
----
-'@ant-design/web3-icons': minor
----
-
-feat: new icon SlushCircleFilled

--- a/examples/eth-web3js/CHANGELOG.md
+++ b/examples/eth-web3js/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @example/eth-web3js
 
+## 0.0.24
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+- @ant-design/web3@1.25.1
+- @ant-design/web3-eth-web3js@1.1.21
+
 ## 0.0.23
 
 ### Patch Changes

--- a/examples/eth-web3js/package.json
+++ b/examples/eth-web3js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/eth-web3js",
   "private": true,
-  "version": "0.0.23",
+  "version": "0.0.24",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers-v5/CHANGELOG.md
+++ b/examples/ethers-v5/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @example/ethers-v5
 
+## 0.0.24
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+- @ant-design/web3@1.25.1
+- @ant-design/web3-ethers-v5@1.0.22
+
 ## 0.0.23
 
 ### Patch Changes

--- a/examples/ethers-v5/package.json
+++ b/examples/ethers-v5/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers-v5",
   "private": true,
-  "version": "0.0.23",
+  "version": "0.0.24",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/examples/ethers/CHANGELOG.md
+++ b/examples/ethers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @example/ethers
 
+## 0.0.24
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+- @ant-design/web3@1.25.1
+- @ant-design/web3-ethers@1.1.21
+
 ## 0.0.23
 
 ### Patch Changes

--- a/examples/ethers/package.json
+++ b/examples/ethers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@example/ethers",
   "private": true,
-  "version": "0.0.23",
+  "version": "0.0.24",
   "author": "Jeason <me@cowpoke.cc>",
   "type": "module",
   "scripts": {

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ant-design/web3-assets
 
+## 1.14.1
+
+### Patch Changes
+
+- Updated dependencies [31a8965]
+  - @ant-design/web3-icons@1.15.0
+
 ## 1.14.0
 
 ### Minor Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-assets",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/bitcoin/CHANGELOG.md
+++ b/packages/bitcoin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ant-design/web3-bitcoin
 
+## 2.0.2
+
+### Patch Changes
+
+- Updated dependencies [31a8965]
+  - @ant-design/web3-icons@1.15.0
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-bitcoin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/eth-web3js/CHANGELOG.md
+++ b/packages/eth-web3js/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ant-design/web3-eth-web3js
 
+## 1.1.21
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+- @ant-design/web3-wagmi@2.12.1
+
 ## 1.1.20
 
 ### Patch Changes

--- a/packages/eth-web3js/package.json
+++ b/packages/eth-web3js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-eth-web3js",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers-v5/CHANGELOG.md
+++ b/packages/ethers-v5/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ant-design/web3-ethers-v5
 
+## 1.0.22
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+- @ant-design/web3-ethers@1.1.21
+- @ant-design/web3-wagmi@2.12.1
+
 ## 1.0.21
 
 ### Patch Changes

--- a/packages/ethers-v5/package.json
+++ b/packages/ethers-v5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers-v5",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ethers/CHANGELOG.md
+++ b/packages/ethers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ant-design/web3-ethers
 
+## 1.1.21
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+- @ant-design/web3-wagmi@2.12.1
+
 ## 1.1.20
 
 ### Patch Changes

--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ethers",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-icons
 
+## 1.15.0
+
+### Minor Changes
+
+- 31a8965: feat: new icon SlushCircleFilled
+
 ## 1.14.0
 
 ### Minor Changes

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-icons",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/solana/CHANGELOG.md
+++ b/packages/solana/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-solana
 
+## 1.4.2
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-solana",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/sui/CHANGELOG.md
+++ b/packages/sui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-sui
 
+## 1.1.1
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/sui/package.json
+++ b/packages/sui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-sui",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/ton/CHANGELOG.md
+++ b/packages/ton/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-ton
 
+## 1.1.3
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/ton/package.json
+++ b/packages/ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-ton",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/tron/CHANGELOG.md
+++ b/packages/tron/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-tron
 
+## 1.0.3
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/tron/package.json
+++ b/packages/tron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-tron",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/lib/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/esm/index.d.ts",

--- a/packages/wagmi/CHANGELOG.md
+++ b/packages/wagmi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ant-design/web3-wagmi
 
+## 2.12.1
+
+### Patch Changes
+
+- @ant-design/web3-assets@1.14.1
+
 ## 2.12.0
 
 ### Minor Changes

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3-wagmi",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ant-design/web3
 
+## 1.25.1
+
+### Patch Changes
+
+- Updated dependencies [31a8965]
+  - @ant-design/web3-icons@1.15.0
+  - @ant-design/web3-assets@1.14.1
+
 ## 1.25.0
 
 ### Minor Changes

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/web3",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
🦋  info Publishing "@ant-design/web3-assets" at "1.14.1"
🦋  info Publishing "@ant-design/web3-bitcoin" at "2.0.2"
🦋  info Publishing "@ant-design/web3-eth-web3js" at "1.1.21"
🦋  info Publishing "@ant-design/web3-ethers" at "1.1.21"
🦋  info Publishing "@ant-design/web3-ethers-v5" at "1.0.22"
🦋  info Publishing "@ant-design/web3-icons" at "1.15.0"
🦋  info Publishing "@ant-design/web3-solana" at "1.4.2"
🦋  info Publishing "@ant-design/web3-sui" at "1.1.1"
🦋  info Publishing "@ant-design/web3-ton" at "1.1.3"
🦋  info Publishing "@ant-design/web3-tron" at "1.0.3"
🦋  info Publishing "@ant-design/web3-wagmi" at "2.12.1"
🦋  info Publishing "@ant-design/web3" at "1.25.1"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 新增图标：SlushCircleFilled。
- 文档
  - 多个包与示例新增变更日志条目，记录补丁级更新与依赖调整。
- 事务
  - 版本升级：web3 1.25.1、icons 1.15.0、assets 1.14.1、wagmi 2.12.1、ethers 1.1.21、ethers-v5 1.0.22、eth-web3js 1.1.21、bitcoin 2.0.2、solana 1.4.2、sui 1.1.1、ton 1.1.3、tron 1.0.3，以及示例应用至 0.0.24；同步相关依赖版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->